### PR TITLE
VerificationResult now has a proper mediaType field.

### DIFF
--- a/cmd/sigstore-go/main.go
+++ b/cmd/sigstore-go/main.go
@@ -172,13 +172,15 @@ func run() error {
 			return err
 		}
 		artifactPolicy = verify.WithArtifactDigest(*artifactDigestAlgorithm, artifactDigestBytes)
-	}
-	if *artifact != "" {
+	} else if *artifact != "" {
 		file, err := os.Open(*artifact)
 		if err != nil {
 			return err
 		}
 		artifactPolicy = verify.WithArtifact(file)
+	} else {
+		artifactPolicy = verify.WithoutArtifactUnsafe()
+		fmt.Fprintf(os.Stderr, "No artifact provided, skipping artifact verification. This is unsafe!\n")
 	}
 
 	res, err := sev.Verify(b, verify.NewPolicy(artifactPolicy, identityPolicies...))

--- a/cmd/sigstore-go/main.go
+++ b/cmd/sigstore-go/main.go
@@ -166,7 +166,7 @@ func run() error {
 		return err
 	}
 
-	if *artifactDigest != "" {
+	if *artifactDigest != "" { //nolint:gocritic
 		artifactDigestBytes, err := hex.DecodeString(*artifactDigest)
 		if err != nil {
 			return err

--- a/pkg/verify/signed_entity.go
+++ b/pkg/verify/signed_entity.go
@@ -25,6 +25,10 @@ import (
 	"github.com/sigstore/sigstore-go/pkg/root"
 )
 
+const (
+	VerificationResultMediaType01 = "application/vnd.dev.sigstore.verificationresult+json;version=0.1"
+)
+
 type SignedEntityVerifier struct {
 	trustedMaterial root.TrustedMaterial
 	config          VerifierConfig
@@ -174,7 +178,7 @@ type TimestampVerificationResult struct {
 
 func NewVerificationResult() *VerificationResult {
 	return &VerificationResult{
-		MediaType: "application/vnd.dev.sigstore.verificationresult+json;version=0.1",
+		MediaType: VerificationResultMediaType01,
 	}
 }
 

--- a/pkg/verify/signed_entity.go
+++ b/pkg/verify/signed_entity.go
@@ -154,7 +154,7 @@ func (c *VerifierConfig) Validate() error {
 }
 
 type VerificationResult struct {
-	Version            int                           `json:"version"`
+	MediaType          string                        `json:"mediaType"`
 	Statement          *in_toto.Statement            `json:"statement,omitempty"`
 	Signature          *SignatureVerificationResult  `json:"signature,omitempty"`
 	VerifiedTimestamps []TimestampVerificationResult `json:"verifiedTimestamps"`
@@ -174,7 +174,7 @@ type TimestampVerificationResult struct {
 
 func NewVerificationResult() *VerificationResult {
 	return &VerificationResult{
-		Version: 20230823,
+		MediaType: "application/vnd.dev.sigstore.verificationresult+json;version=0.1",
 	}
 }
 
@@ -193,9 +193,11 @@ func (pc PolicyBuilder) Options() []PolicyOption {
 }
 
 func (pc PolicyBuilder) BuildConfig() (*PolicyConfig, error) {
+	var err error
+
 	policy := &PolicyConfig{}
 	for _, applyOption := range pc.Options() {
-		err := applyOption(policy)
+		err = applyOption(policy)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

Closes https://github.com/sigstore/sigstore-go/issues/13

As described in the issue, this PR solves the problem of `VerificationResults.Version` being insufficiently descriptive and incongruous with the other json document types that are handled in the broader Sigstore ecosystem.

This PR:
- Changes it from `Version int` to `MediaType string`
- Updates the default value to `application/vnd.dev.sigstore.verificationresult+json;version=0.1`
- And for good measure, adds the option to use `WithoutArtifactUnsafe()` in the `sigstore-go` binary, which I used to test this feature.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note

- Changed VerificationResult.Version to VerificationResult.MediaType

<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation

We haven't created a release for this yet, so I don't think any additional docs changes are necessary beyond what will be generated when we do create a release for this library.

<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
