### PR TITLE
Have conformance test require signed timestamps for bundles v02

### DIFF
--- a/cmd/conformance/main.go
+++ b/cmd/conformance/main.go
@@ -222,7 +222,19 @@ func main() {
 		tr := getTrustedRoot()
 
 		// Verify bundle
-		sev, err := verify.NewSignedEntityVerifier(tr, verify.WithTransparencyLog(1), verify.WithSignedCertificateTimestamps(1))
+		verifierConfig := []verify.VerifierOption{}
+		verifierConfig = append(verifierConfig, verify.WithSignedCertificateTimestamps(1))
+
+		switch b.Bundle.MediaType {
+		case bundle.SigstoreBundleMediaType01:
+			verifierConfig = append(verifierConfig, verify.WithTransparencyLog(1))
+		case bundle.SigstoreBundleMediaType02:
+			verifierConfig = append(verifierConfig, verify.WithSignedTimestamps(1))
+		default:
+			log.Fatalf("Unknown bundle media type: %s", b.Bundle.MediaType)
+		}
+
+		sev, err := verify.NewSignedEntityVerifier(tr, verifierConfig...)
 		if err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This is a bit of a philosophical question, although either `sigstore-go` needs to behave this way or we need to change `test_verify_rejects_bad_tsa_timestamp` that was added in https://github.com/sigstore/sigstore-conformance/pull/112.

In that conformance test, we have a bundle with media type v0.2 that includes `timestampVerificationData` (so far so good). But it also includes an `inclusionPromise.signedEntryTimestamp`, and it expects verification to fail when `timestampVerificationData` is incorrect but `inclusionPromise.signedEntryTimestamp` is correct.

This change makes it so v0.2 bundles require valid `timestampVerificationData` and for those bundles ignores `inclusionPromise.signedEntryTimestamp`. It's possible that instead we want to require any information provided to be valid.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

N/A