### PR TITLE
Don't fail on Rekor entry verification for untrusted entries

### DIFF
--- a/pkg/tlog/entry.go
+++ b/pkg/tlog/entry.go
@@ -230,6 +230,10 @@ func (entry *Entry) LogIndex() int64 {
 	return *entry.logEntryAnon.LogIndex
 }
 
+func (entry *Entry) Body() any {
+	return entry.logEntryAnon.Body
+}
+
 func (entry *Entry) HasInclusionPromise() bool {
 	return entry.signedEntryTimestamp != nil
 }

--- a/pkg/verify/sct.go
+++ b/pkg/verify/sct.go
@@ -29,6 +29,7 @@ import (
 // leaf certificate, will extract SCTs from the leaf certificate and verify the
 // timestamps using the TrustedMaterial's FulcioCertificateAuthorities() and
 // CTlogAuthorities()
+// TODO(issue#46): Add unit tests
 func VerifySignedCertificateTimestamp(leafCert *x509.Certificate, threshold int, trustedMaterial root.TrustedMaterial) error { // nolint: revive
 	ctlogs := trustedMaterial.CTlogAuthorities()
 	fulcioCerts := trustedMaterial.FulcioCertificateAuthorities()
@@ -48,7 +49,8 @@ func VerifySignedCertificateTimestamp(leafCert *x509.Certificate, threshold int,
 		encodedKeyID := hex.EncodeToString(sct.LogID.KeyID[:])
 		key, ok := ctlogs[encodedKeyID]
 		if !ok {
-			return fmt.Errorf("unable to find ctlogs key for %s", encodedKeyID)
+			// skip entries the trust root cannot verify
+			continue
 		}
 
 		for _, fulcioCa := range fulcioCerts {

--- a/pkg/verify/tlog.go
+++ b/pkg/verify/tlog.go
@@ -77,7 +77,9 @@ func VerifyArtifactTransparencyLog(entity SignedEntity, trustedMaterial root.Tru
 		}
 
 		if !online {
-			// TODO: do we validate that an entry has EITHER a promise OR a proof?
+			if !entry.HasInclusionPromise() && !entry.HasInclusionProof() {
+				return nil, fmt.Errorf("entry must contain and inclusion proof and/or promise")
+			}
 			if entry.HasInclusionPromise() {
 				err = tlog.VerifySET(entry, trustedMaterial.TlogAuthorities())
 				if err != nil {

--- a/pkg/verify/tlog.go
+++ b/pkg/verify/tlog.go
@@ -78,7 +78,7 @@ func VerifyArtifactTransparencyLog(entity SignedEntity, trustedMaterial root.Tru
 
 		if !online {
 			if !entry.HasInclusionPromise() && !entry.HasInclusionProof() {
-				return nil, fmt.Errorf("entry must contain and inclusion proof and/or promise")
+				return nil, fmt.Errorf("entry must contain an inclusion proof and/or promise")
 			}
 			if entry.HasInclusionPromise() {
 				err = tlog.VerifySET(entry, trustedMaterial.TlogAuthorities())

--- a/pkg/verify/tlog_test.go
+++ b/pkg/verify/tlog_test.go
@@ -52,18 +52,18 @@ func TestTlogVerifier(t *testing.T) {
 	assert.Error(t, err)
 }
 
-type goodAndUntrustedLogEntry struct {
+type oneTrustedOneUntrustedLogEntry struct {
 	*ca.TestEntity
-	OtherTestEntity *ca.TestEntity
+	UntrustedTestEntity *ca.TestEntity
 }
 
-func (e *goodAndUntrustedLogEntry) TlogEntries() ([]*tlog.Entry, error) {
+func (e *oneTrustedOneUntrustedLogEntry) TlogEntries() ([]*tlog.Entry, error) {
 	entries, err := e.TestEntity.TlogEntries()
 	if err != nil {
 		return nil, err
 	}
 
-	otherEntries, err := e.OtherTestEntity.TlogEntries()
+	otherEntries, err := e.UntrustedTestEntity.TlogEntries()
 	if err != nil {
 		return nil, err
 	}
@@ -79,17 +79,17 @@ func TestIgnoredTLogEntries(t *testing.T) {
 	entity, err := virtualSigstore.Attest("foo@fighters.com", "issuer", statement)
 	assert.NoError(t, err)
 
-	otherSigstore, err := ca.NewVirtualSigstore()
+	untrustedSigstore, err := ca.NewVirtualSigstore()
 	assert.NoError(t, err)
-	otherEntity, err := otherSigstore.Attest("foo@fighters.com", "issuer", statement)
+	untrustedEntity, err := untrustedSigstore.Attest("foo@fighters.com", "issuer", statement)
 	assert.NoError(t, err)
 
 	// success: entry that cannot be verified is ignored
-	_, err = verify.VerifyArtifactTransparencyLog(&goodAndUntrustedLogEntry{entity, otherEntity}, virtualSigstore, 1, false)
+	_, err = verify.VerifyArtifactTransparencyLog(&oneTrustedOneUntrustedLogEntry{entity, untrustedEntity}, virtualSigstore, 1, false)
 	assert.NoError(t, err)
 
 	// failure: threshold of 2 is not met since 1 untrusted entry is ignored
-	_, err = verify.VerifyArtifactTransparencyLog(&goodAndUntrustedLogEntry{entity, otherEntity}, virtualSigstore, 2, false)
+	_, err = verify.VerifyArtifactTransparencyLog(&oneTrustedOneUntrustedLogEntry{entity, untrustedEntity}, virtualSigstore, 2, false)
 	assert.Error(t, err)
 }
 

--- a/pkg/verify/tlog_test.go
+++ b/pkg/verify/tlog_test.go
@@ -15,6 +15,8 @@
 package verify_test
 
 import (
+	"encoding/base64"
+	"strings"
 	"testing"
 	"time"
 
@@ -91,6 +93,71 @@ func TestIgnoredTLogEntries(t *testing.T) {
 	// failure: threshold of 2 is not met since 1 untrusted entry is ignored
 	_, err = verify.VerifyArtifactTransparencyLog(&oneTrustedOneUntrustedLogEntry{entity, untrustedEntity}, virtualSigstore, 2, false)
 	assert.Error(t, err)
+}
+
+// invalidTLogEntity constructs a bundle with a Rekor response, but without an inclusion proof or promise
+type invalidTLogEntity struct {
+	*ca.TestEntity
+}
+
+func (e *invalidTLogEntity) TlogEntries() ([]*tlog.Entry, error) {
+	entries, err := e.TestEntity.TlogEntries()
+	if err != nil {
+		return nil, err
+	}
+	var invalidEntries []*tlog.Entry
+	for _, entry := range entries {
+		body, err := base64.StdEncoding.DecodeString(entry.Body().(string))
+		if err != nil {
+			return nil, err
+		}
+		invalidEntry, err := tlog.NewEntry(body, entry.IntegratedTime().Unix(), entry.LogIndex(), []byte(entry.LogKeyID()), nil, nil)
+		if err != nil {
+			return nil, err
+		}
+		invalidEntries = append(invalidEntries, invalidEntry)
+	}
+	return invalidEntries, nil
+}
+
+func TestInvalidTLogEntries(t *testing.T) {
+	statement := []byte(`{"_type":"https://in-toto.io/Statement/v0.1","predicateType":"customFoo","subject":[{"name":"subject","digest":{"sha256":"deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"}}],"predicate":{}}`)
+
+	virtualSigstore, err := ca.NewVirtualSigstore()
+	assert.NoError(t, err)
+	entity, err := virtualSigstore.Attest("foo@fighters.com", "issuer", statement)
+	assert.NoError(t, err)
+
+	// failure: threshold of 1 is not met with invalid entry
+	_, err = verify.VerifyArtifactTransparencyLog(&invalidTLogEntity{entity}, virtualSigstore, 1, false)
+	assert.Error(t, err)
+	if err.Error() != "entry must contain and inclusion proof and/or promise" {
+		t.Errorf("expected error with missing proof/promises, got: %v", err.Error())
+	}
+}
+
+type noTLogEntity struct {
+	*ca.TestEntity
+}
+
+func (e *noTLogEntity) TlogEntries() ([]*tlog.Entry, error) {
+	return []*tlog.Entry{}, nil
+}
+
+func TestNoTLogEntries(t *testing.T) {
+	statement := []byte(`{"_type":"https://in-toto.io/Statement/v0.1","predicateType":"customFoo","subject":[{"name":"subject","digest":{"sha256":"deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"}}],"predicate":{}}`)
+
+	virtualSigstore, err := ca.NewVirtualSigstore()
+	assert.NoError(t, err)
+	entity, err := virtualSigstore.Attest("foo@fighters.com", "issuer", statement)
+	assert.NoError(t, err)
+
+	// failure: threshold of 1 is not met with no entries
+	_, err = verify.VerifyArtifactTransparencyLog(&noTLogEntity{entity}, virtualSigstore, 1, false)
+	assert.Error(t, err)
+	if !strings.Contains(err.Error(), "not enough verified timestamps from transparency log") {
+		t.Errorf("expected error with timestamp threshold, got: %v", err.Error())
+	}
 }
 
 type dupTlogEntity struct {

--- a/pkg/verify/tlog_test.go
+++ b/pkg/verify/tlog_test.go
@@ -131,7 +131,7 @@ func TestInvalidTLogEntries(t *testing.T) {
 	// failure: threshold of 1 is not met with invalid entry
 	_, err = verify.VerifyArtifactTransparencyLog(&invalidTLogEntity{entity}, virtualSigstore, 1, false)
 	assert.Error(t, err)
-	if err.Error() != "entry must contain and inclusion proof and/or promise" {
+	if err.Error() != "entry must contain an inclusion proof and/or promise" {
 		t.Errorf("expected error with missing proof/promises, got: %v", err.Error())
 	}
 }


### PR DESCRIPTION
Like #45, as long as the threshold of expected timestamps is met, then verification should succeed. Otherwise, entries without trust root material should be skipped.

One benefit of having the log key ID be used to look up the correct trust root material is that we can still error out if the signature is invalid.

Fixes #43

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
