### PR TITLE
Bundle verification should require specifying expected certificate issuer and SAN

### DIFF
--- a/cmd/sigstore-go/main.go
+++ b/cmd/sigstore-go/main.go
@@ -113,13 +113,11 @@ func run() error {
 		verifierConfig = append(verifierConfig, verify.WithOnlineVerification())
 	}
 
-	if *expectedOIDIssuer != "" || *expectedSAN != "" || *expectedSANRegex != "" {
-		certID, err := verify.NewShortCertificateIdentity(*expectedOIDIssuer, *expectedSAN, "", *expectedSANRegex)
-		if err != nil {
-			return err
-		}
-		identityPolicies = append(identityPolicies, verify.WithCertificateIdentity(certID))
+	certID, err := verify.NewShortCertificateIdentity(*expectedOIDIssuer, *expectedSAN, "", *expectedSANRegex)
+	if err != nil {
+		return err
 	}
+	identityPolicies = append(identityPolicies, verify.WithCertificateIdentity(certID))
 
 	var trustedMaterial = make(root.TrustedMaterialCollection, 0)
 	var trustedrootJSON []byte

--- a/pkg/verify/certificate_identity.go
+++ b/pkg/verify/certificate_identity.go
@@ -91,6 +91,10 @@ func (s SubjectAlternativeNameMatcher) Verify(actualCert certificate.Summary) bo
 }
 
 func NewCertificateIdentity(sanMatcher SubjectAlternativeNameMatcher, extensions certificate.Extensions) (CertificateIdentity, error) {
+	if sanMatcher.SubjectAlternativeName.Type == "" && sanMatcher.SubjectAlternativeName.Value == "" && sanMatcher.Regexp.String() == "" {
+		return CertificateIdentity{}, errors.New("when verifying a certificate identity, there must be subject alternative name criteria")
+	}
+
 	certID := CertificateIdentity{SubjectAlternativeName: sanMatcher, Extensions: extensions}
 
 	if certID.Issuer == "" {

--- a/pkg/verify/certificate_identity.go
+++ b/pkg/verify/certificate_identity.go
@@ -91,7 +91,7 @@ func (s SubjectAlternativeNameMatcher) Verify(actualCert certificate.Summary) bo
 }
 
 func NewCertificateIdentity(sanMatcher SubjectAlternativeNameMatcher, extensions certificate.Extensions) (CertificateIdentity, error) {
-	if sanMatcher.SubjectAlternativeName.Type == "" && sanMatcher.SubjectAlternativeName.Value == "" && sanMatcher.Regexp.String() == "" {
+	if sanMatcher.SubjectAlternativeName.Value == "" && sanMatcher.Regexp.String() == "" {
 		return CertificateIdentity{}, errors.New("when verifying a certificate identity, there must be subject alternative name criteria")
 	}
 

--- a/pkg/verify/certificate_identity_test.go
+++ b/pkg/verify/certificate_identity_test.go
@@ -92,15 +92,15 @@ func TestCertificateIdentityVerify(t *testing.T) {
 
 func TestThatCertIDsAreFullySpecified(t *testing.T) {
 	_, err := NewShortCertificateIdentity("", "", "", "")
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 
 	_, err = NewShortCertificateIdentity("foobar", "", "", "")
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 
-	_, err = NewShortCertificateIdentity("", "URI", "", "")
-	assert.NotNil(t, err)
+	_, err = NewShortCertificateIdentity("", "", "", SigstoreSanRegex)
+	assert.Error(t, err)
 
-	_, err = NewShortCertificateIdentity("foobar", "URI", "", "")
+	_, err = NewShortCertificateIdentity("foobar", "", "", SigstoreSanRegex)
 	assert.Nil(t, err)
 }
 

--- a/pkg/verify/certificate_identity_test.go
+++ b/pkg/verify/certificate_identity_test.go
@@ -90,11 +90,17 @@ func TestCertificateIdentityVerify(t *testing.T) {
 	assert.Nil(t, ci)
 }
 
-func TestThatCertIDsHaveToHaveAnIssuer(t *testing.T) {
+func TestThatCertIDsAreFullySpecified(t *testing.T) {
 	_, err := NewShortCertificateIdentity("", "", "", "")
 	assert.NotNil(t, err)
 
 	_, err = NewShortCertificateIdentity("foobar", "", "", "")
+	assert.NotNil(t, err)
+
+	_, err = NewShortCertificateIdentity("", "URI", "", "")
+	assert.NotNil(t, err)
+
+	_, err = NewShortCertificateIdentity("foobar", "URI", "", "")
 	assert.Nil(t, err)
 }
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

Since many OIDC issuers are shared platforms, you need to ensure the Fulcio certificate SAN identity matches the identity on that platform you are expecting.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
* Bundle verification now requires not just specifying expected certificate issuer, but also expected identity via the certificate SAN 

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

N/A