### PR TITLE
Add partial example of signing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+VERSION := `git describe --tags`
+LDFLAGS = -ldflags "-X main.Version=$(VERSION)"
+
 .PHONY: build
 build:
-	go build ./cmd/sigstore-go
-	go build -o conformance ./cmd/conformance
+	go build $(LDFLAGS) ./cmd/sigstore-go
+	go build $(LDFLAGS) -o conformance ./cmd/conformance
 
 .PHONY: test
 test:

--- a/examples/signing/main.go
+++ b/examples/signing/main.go
@@ -1,0 +1,68 @@
+// Copyright 2024 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"log"
+
+	protocommon "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	"github.com/sigstore/sigstore-go/pkg/sign"
+)
+
+func main() {
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Print out privateKey.PublicKey() in PEM format
+	pubKeyBytes, err := x509.MarshalPKIXPublicKey(&privateKey.PublicKey)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	pemBlock := pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: pubKeyBytes,
+	}
+	fmt.Println(string(pem.EncodeToMemory(&pemBlock)))
+
+	signer := sign.SignerKeypair(privateKey, protocommon.HashAlgorithm_SHA2_256, []byte("someKeyHint"))
+	bundle, err := signer.Sign([]byte("hello world"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	witness := sign.WitnessTimestampAuthority("https://timestamp.githubapp.com")
+	err = witness.Witness(bundle)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	bundleJSON, err := protojson.Marshal(bundle)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(string(bundleJSON))
+}

--- a/pkg/sign/signer.go
+++ b/pkg/sign/signer.go
@@ -18,7 +18,7 @@ import (
 	"crypto"
 	"crypto/rand"
 	"crypto/sha256"
-	_ "crypto/sha512" // if user chooses SHA2-384 or SHA2-256 for hash
+	_ "crypto/sha512" // if user chooses SHA2-384 or SHA2-512 for hash
 	"crypto/x509"
 	"encoding/base64"
 	"errors"

--- a/pkg/sign/signer.go
+++ b/pkg/sign/signer.go
@@ -1,0 +1,95 @@
+// Copyright 2024 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sign
+
+import (
+	"crypto"
+	"crypto/rand"
+	_ "crypto/sha256" // hash function will be used by Sign
+	_ "crypto/sha512" // hash function will be used by Sign
+	"errors"
+
+	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
+	protocommon "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
+)
+
+type Signer interface {
+	Sign(data []byte) (*protobundle.Bundle, error)
+}
+
+// TODO: implement
+// type Fulcio struct {
+//	baseURL       string
+//	identityToken string
+// }
+
+// func (f *Fulcio) Sign(data []byte) (*protobundle.Bundle, error) {}
+
+type Keypair struct {
+	signer        crypto.Signer
+	hashAlgorithm protocommon.HashAlgorithm
+	publicKeyHint []byte
+}
+
+func SignerKeypair(s crypto.Signer, ha protocommon.HashAlgorithm, pkh []byte) Keypair {
+	return Keypair{signer: s, hashAlgorithm: ha, publicKeyHint: pkh}
+}
+
+func (k Keypair) Sign(data []byte) (*protobundle.Bundle, error) {
+	bundle := protobundle.Bundle{
+		MediaType: "application/vnd.dev.sigstore.bundle.v0.3+json",
+		VerificationMaterial: &protobundle.VerificationMaterial{
+			Content: &protobundle.VerificationMaterial_PublicKey{
+				PublicKey: &protocommon.PublicKeyIdentifier{
+					Hint: string(k.publicKeyHint),
+				},
+			},
+		},
+	}
+
+	var hashFunc crypto.Hash
+
+	switch k.hashAlgorithm {
+	case protocommon.HashAlgorithm_SHA2_256:
+		hashFunc = crypto.Hash(crypto.SHA256)
+	case protocommon.HashAlgorithm_SHA2_384:
+		hashFunc = crypto.Hash(crypto.SHA384)
+	case protocommon.HashAlgorithm_SHA2_512:
+		hashFunc = crypto.Hash(crypto.SHA512)
+	default:
+		return nil, errors.New("Unsupported hash algorithm")
+	}
+
+	hasher := hashFunc.New()
+	hasher.Write(data)
+	digest := hasher.Sum(nil)
+
+	signature, err := k.signer.Sign(rand.Reader, digest, hashFunc)
+	if err != nil {
+		return nil, err
+	}
+
+	bundle.Content = &protobundle.Bundle_MessageSignature{
+		MessageSignature: &protocommon.MessageSignature{
+			MessageDigest: &protocommon.HashOutput{
+				Algorithm: k.hashAlgorithm,
+				Digest:    digest,
+			},
+			Signature: signature,
+		},
+	}
+
+	return &bundle, nil
+}

--- a/pkg/sign/witness.go
+++ b/pkg/sign/witness.go
@@ -1,0 +1,113 @@
+// Copyright 2024 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sign
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/sha256"
+	"io"
+
+	"github.com/digitorus/timestamp"
+	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
+	protocommon "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
+	tsaclient "github.com/sigstore/timestamp-authority/pkg/client"
+	tsagenclient "github.com/sigstore/timestamp-authority/pkg/generated/client/timestamp"
+)
+
+type Witness interface {
+	Witness(*protobundle.Bundle) error
+}
+
+type TimestampAuthority struct {
+	baseURL string
+}
+
+func WitnessTimestampAuthority(baseURL string) TimestampAuthority {
+	return TimestampAuthority{
+		baseURL: baseURL,
+	}
+}
+
+func (ta *TimestampAuthority) Witness(b *protobundle.Bundle) error {
+	req := &timestamp.Request{
+		Certificates: true,
+	}
+
+	messageSignature := b.GetMessageSignature()
+
+	if messageSignature != nil {
+		signatureHash := sha256.Sum256(messageSignature.Signature)
+		req.HashAlgorithm = crypto.SHA256
+		req.HashedMessage = signatureHash[:]
+	}
+
+	reqBytes, err := req.Marshal()
+	if err != nil {
+		return err
+	}
+
+	client, err := tsaclient.GetTimestampClient(ta.baseURL, tsaclient.WithUserAgent("sigstore-go"), tsaclient.WithContentType(tsaclient.TimestampQueryMediaType))
+	if err != nil {
+		return err
+	}
+
+	clientParams := tsagenclient.NewGetTimestampResponseParams()
+	// TODO: call clientParams.SetTimeout()
+	clientParams.Request = io.NopCloser(bytes.NewReader(reqBytes))
+
+	var respBytes bytes.Buffer
+	_, err = client.Timestamp.GetTimestampResponse(clientParams, &respBytes)
+	if err != nil {
+		return err
+	}
+
+	_, err = timestamp.ParseResponse(respBytes.Bytes())
+	if err != nil {
+		return err
+	}
+
+	signedTimestamp := &protocommon.RFC3161SignedTimestamp{
+		SignedTimestamp: respBytes.Bytes(),
+	}
+
+	vm := b.GetVerificationMaterial()
+	if vm == nil {
+		vm = &protobundle.VerificationMaterial{}
+		b.VerificationMaterial = vm
+	}
+
+	tsVerificationData := vm.GetTimestampVerificationData()
+	if tsVerificationData == nil {
+		tsVerificationData = &protobundle.TimestampVerificationData{}
+		vm.TimestampVerificationData = tsVerificationData
+	}
+
+	tsVerificationData.Rfc3161Timestamps = append(tsVerificationData.Rfc3161Timestamps, signedTimestamp)
+
+	return nil
+}
+
+// TODO: implement
+// type Rekor struct {
+//	baseURL   string
+//	entryType string
+// }
+
+// func (r *Rekor) Witness(_ *protobundle.Bundle) error {
+//	// hashedrekord uses signature and dataDigest
+//	// dsse uses envelope and ephemeralPublicKey
+//	return nil
+// }


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

For #136.

This isn't a full implementation of signing - it supports an on-disk keypair and a timestamp authority. It doesn't yet support Fulcio or Rekor. But I wanted to post a work-in-progress to get feedback on signing API generally.

We could choose to land this functionality and have a follow-on PR that implements Fulcio and Rekor support (and enables conformance testing on signing) - smaller reviews are nice! Or I could continue to update this PR with more functionality.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

NONE - for now, until at least Fulcio is supported

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

NONE