### PR TITLE
Add mediatype string builder to bundle package

### DIFF
--- a/pkg/bundle/bundle_test.go
+++ b/pkg/bundle/bundle_test.go
@@ -17,6 +17,8 @@ package bundle
 import (
 	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func Test_getBundleVersion(t *testing.T) {
@@ -91,6 +93,34 @@ func Test_getBundleVersion(t *testing.T) {
 			if got != tt.want {
 				t.Errorf("getBundleVersion() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestMediaTypeString(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name     string
+		ver      string
+		expected string
+		mustErr  bool
+	}{
+		{"normal-semver", "v0.3", "application/vnd.dev.sigstore.bundle.v0.3+json", false},
+		{"old-semver1", "v0.1", "application/vnd.dev.sigstore.bundle+json;version=0.1", false},
+		{"old-semver2", "v0.2", "application/vnd.dev.sigstore.bundle+json;version=0.2", false},
+		{"blank", "", "", true},
+		{"invalid", "garbage", "", true},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			res, err := MediaTypeString(tc.ver)
+			if tc.mustErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, res)
 		})
 	}
 }


### PR DESCRIPTION




#### Summary

This commit adds a media type string build function to handle the media type string in the module.

With the release of 0.3 all apps relying on the media type constants in `pkg/bundle` broke as the constants were removed in https://github.com/sigstore/sigstore-go/commit/20c2ce9c55fc2d05bf01604c491edfe46e43e4dc. This PR introduces a function to generate the media type string from the module and avoid spreading media type strings on applications using the module.

Fixes: https://github.com/sigstore/sigstore-go/issues/153

/cc @codysoyland 

#### Release Note

Added a `bundle.MediaTypeString()` function to handle the media type strings from the bundle module

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
