### PR TITLE
Add clarifying comments around TUF caching options

### DIFF
--- a/pkg/tuf/client_test.go
+++ b/pkg/tuf/client_test.go
@@ -167,6 +167,23 @@ func TestCache(t *testing.T) {
 	target, err = c.GetTarget("foo")
 	assert.NoError(t, err)
 	assert.Equal(t, target, []byte("foo version 2"))
+
+	r.AddTarget("foo", []byte("foo version 3"))
+
+	// Delete config to show that client fetches fresh metadata when no config is present
+	if err = os.Remove(c.configPath()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create another new client with the same cache path
+	c, err = New(opt)
+	assert.NotNil(t, c)
+	assert.NoError(t, err)
+
+	// Cache contains new version
+	target, err = c.GetTarget("foo")
+	assert.NoError(t, err)
+	assert.Equal(t, target, []byte("foo version 3"))
 }
 
 func TestExpiredTimestamp(t *testing.T) {

--- a/pkg/tuf/options.go
+++ b/pkg/tuf/options.go
@@ -36,13 +36,20 @@ const (
 
 // Options represent the various options for a Sigstore TUF Client
 type Options struct {
-	// CacheValidity period in days (default 0). Note that the client will
-	// always refresh the cache if the metadata is expired, so this is not an
-	// optimal control for air-gapped environments. Use const MaxCache to only
-	// update the cache when the metadata is expired.
+	// CacheValidity period in days (default 0). The client will persist a
+	// timestamp with the cache after refresh. Note that the client will
+	// always refresh the cache if the metadata is expired or if the client is
+	// unable to find a persisted timestamp, so this is not an optimal control
+	// for air-gapped environments. Use const MaxCache to update the cache when
+	// the metadata is expired, though the first initialization will still
+	// refresh the cache.
 	CacheValidity int
 	// ForceCache controls if the cache should be used without update
-	// as long as the metadata is valid
+	// as long as the metadata is valid. Use ForceCache over CacheValidity
+	// if you want to always use the cache up until its expiration. Note that
+	// the client will refresh the cache once the metadata has expired, so this
+	// is not an optimal control for air-gapped environments. Clients instead
+	// should provide a trust root file directly to the client to bypass TUF.
 	ForceCache bool
 	// Root is the TUF trust anchor
 	Root []byte


### PR DESCRIPTION
This changes the behavior of the TUF client to use the cached metadata if it's unexpired on first initialization. Previously, if no config which included the last update timestamp was found, it would force a reinitialization. Now, the first init with cached metadata will be offline.

Fixes https://github.com/sigstore/sigstore-go/issues/162

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
