### PR TITLE
feat: use GetLogEntryByIndex to query rekor

### DIFF
--- a/pkg/verify/tlog.go
+++ b/pkg/verify/tlog.go
@@ -26,7 +26,6 @@ import (
 	rekorClient "github.com/sigstore/rekor/pkg/client"
 	rekorGeneratedClient "github.com/sigstore/rekor/pkg/generated/client"
 	rekorEntries "github.com/sigstore/rekor/pkg/generated/client/entries"
-	rekorModels "github.com/sigstore/rekor/pkg/generated/models"
 	rekorVerify "github.com/sigstore/rekor/pkg/verify"
 	"github.com/sigstore/sigstore/pkg/signature"
 
@@ -131,13 +130,10 @@ func VerifyArtifactTransparencyLog(entity SignedEntity, trustedMaterial root.Tru
 
 			logIndex := entry.LogIndex()
 
-			// TODO(issue#52): Change to GetLogEntryByIndex
-			searchParams := rekorEntries.NewSearchLogQueryParams()
-			searchLogQuery := rekorModels.SearchLogQuery{}
-			searchLogQuery.LogIndexes = []*int64{&logIndex}
-			searchParams.SetEntry(&searchLogQuery)
+			searchParams := rekorEntries.NewGetLogEntryByIndexParams()
+			searchParams.LogIndex = logIndex
 
-			resp, err := client.Entries.SearchLogQuery(searchParams)
+			resp, err := client.Entries.GetLogEntryByIndex(searchParams)
 			if err != nil {
 				return nil, err
 			}
@@ -148,7 +144,7 @@ func VerifyArtifactTransparencyLog(entity SignedEntity, trustedMaterial root.Tru
 				return nil, errors.New("too many log entries returned")
 			}
 
-			logEntry := resp.Payload[0]
+			logEntry := resp.Payload
 
 			for _, v := range logEntry {
 				v := v

--- a/pkg/verify/tlog.go
+++ b/pkg/verify/tlog.go
@@ -140,8 +140,6 @@ func VerifyArtifactTransparencyLog(entity SignedEntity, trustedMaterial root.Tru
 
 			if len(resp.Payload) == 0 {
 				return nil, fmt.Errorf("unable to locate log entry %d", logIndex)
-			} else if len(resp.Payload) > 1 {
-				return nil, errors.New("too many log entries returned")
 			}
 
 			logEntry := resp.Payload


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

Closes: #52

Replaces SearchLogQuery with GetLogEntryByIndex which always returns a single log entry.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
#### TODO
Add unit tests
#### Release Note
NONE
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
NONE
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
