### PR TITLE
Add certificate interface to allow for non-Fulcio certificate authorities

### DIFF
--- a/cmd/conformance/main.go
+++ b/cmd/conformance/main.go
@@ -136,7 +136,7 @@ func signBundle(withRekor bool) (*protobundle.Bundle, error) {
 		Timeout:        timeout,
 		LibraryVersion: Version,
 	}
-	signingOptions.Fulcio = sign.NewFulcio(fulcioOpts)
+	signingOptions.Certificate = sign.NewFulcio(fulcioOpts)
 	signingOptions.IDToken = *identityToken
 
 	if withRekor {

--- a/cmd/conformance/main.go
+++ b/cmd/conformance/main.go
@@ -136,8 +136,8 @@ func signBundle(withRekor bool) (*protobundle.Bundle, error) {
 		Timeout:        timeout,
 		LibraryVersion: Version,
 	}
-	signingOptions.CertificateAuthority = sign.NewFulcio(fulcioOpts)
-	signingOptions.CertificateAuthorityOptions = &sign.CertificateAuthorityOptions{
+	signingOptions.CertificateProvider = sign.NewFulcio(fulcioOpts)
+	signingOptions.CertificateProviderOptions = &sign.CertificateProviderOptions{
 		IDToken: *identityToken,
 	}
 

--- a/cmd/conformance/main.go
+++ b/cmd/conformance/main.go
@@ -136,8 +136,10 @@ func signBundle(withRekor bool) (*protobundle.Bundle, error) {
 		Timeout:        timeout,
 		LibraryVersion: Version,
 	}
-	signingOptions.Certificate = sign.NewFulcio(fulcioOpts)
-	signingOptions.IDToken = *identityToken
+	signingOptions.CertificateAuthority = sign.NewFulcio(fulcioOpts)
+	signingOptions.CertificateAuthorityOptions = &sign.CertificateAuthorityOptions{
+		IDToken: *identityToken,
+	}
 
 	if withRekor {
 		rekorOpts := &sign.RekorOptions{

--- a/examples/signing/main.go
+++ b/examples/signing/main.go
@@ -111,8 +111,8 @@ func main() {
 			Retries:        1,
 			LibraryVersion: Version,
 		}
-		opts.CertificateAuthority = sign.NewFulcio(fulcioOpts)
-		opts.CertificateAuthorityOptions = &sign.CertificateAuthorityOptions{
+		opts.CertificateProvider = sign.NewFulcio(fulcioOpts)
+		opts.CertificateProviderOptions = &sign.CertificateProviderOptions{
 			IDToken: *idToken,
 		}
 	}

--- a/examples/signing/main.go
+++ b/examples/signing/main.go
@@ -111,7 +111,7 @@ func main() {
 			Retries:        1,
 			LibraryVersion: Version,
 		}
-		opts.Fulcio = sign.NewFulcio(fulcioOpts)
+		opts.Certificate = sign.NewFulcio(fulcioOpts)
 		opts.IDToken = *idToken
 	}
 

--- a/examples/signing/main.go
+++ b/examples/signing/main.go
@@ -111,8 +111,10 @@ func main() {
 			Retries:        1,
 			LibraryVersion: Version,
 		}
-		opts.Certificate = sign.NewFulcio(fulcioOpts)
-		opts.IDToken = *idToken
+		opts.CertificateAuthority = sign.NewFulcio(fulcioOpts)
+		opts.CertificateAuthorityOptions = &sign.CertificateAuthorityOptions{
+			IDToken: *idToken,
+		}
 	}
 
 	if *tsa {

--- a/pkg/sign/certificate.go
+++ b/pkg/sign/certificate.go
@@ -29,6 +29,10 @@ import (
 	"time"
 )
 
+type Certificate interface {
+	GetCertificate(context.Context, Keypair, string) ([]byte, error)
+}
+
 type Fulcio struct {
 	options *FulcioOptions
 	client  *http.Client

--- a/pkg/sign/certificate.go
+++ b/pkg/sign/certificate.go
@@ -29,13 +29,13 @@ import (
 	"time"
 )
 
-type CertificateAuthorityOptions struct {
-	// Optional OIDC JWT to send to certificate authority; required for Fulcio
+type CertificateProviderOptions struct {
+	// Optional OIDC JWT to send to certificate provider; required for Fulcio
 	IDToken string
 }
 
-type CertificateAuthority interface {
-	GetCertificate(context.Context, Keypair, *CertificateAuthorityOptions) ([]byte, error)
+type CertificateProvider interface {
+	GetCertificate(context.Context, Keypair, *CertificateProviderOptions) ([]byte, error)
 }
 
 type Fulcio struct {
@@ -103,7 +103,7 @@ func NewFulcio(opts *FulcioOptions) *Fulcio {
 }
 
 // Returns DER-encoded code signing certificate
-func (f *Fulcio) GetCertificate(ctx context.Context, keypair Keypair, opts *CertificateAuthorityOptions) ([]byte, error) {
+func (f *Fulcio) GetCertificate(ctx context.Context, keypair Keypair, opts *CertificateProviderOptions) ([]byte, error) {
 	if opts.IDToken == "" {
 		return nil, errors.New("Fulcio requires IDToken to be set")
 	}

--- a/pkg/sign/certificate_test.go
+++ b/pkg/sign/certificate_test.go
@@ -108,7 +108,7 @@ func Test_GetCertificate(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Test malformed idtoken
-	certOpts := &CertificateAuthorityOptions{
+	certOpts := &CertificateProviderOptions{
 		IDToken: "idtoken.notbase64.stuff",
 	}
 	cert, err := fulcio.GetCertificate(ctx, keypair, certOpts)

--- a/pkg/sign/signer.go
+++ b/pkg/sign/signer.go
@@ -35,9 +35,11 @@ type BundleOptions struct {
 	//
 	// Typically a Fulcio instance; resulting bundle will contain a certificate
 	// for its verification material content instead of a public key.
-	Certificate Certificate
-	// Optional OIDC JWT to send to certificate authority; required for Fulcio
-	IDToken string
+	CertificateAuthority CertificateAuthority
+	// Optional options for certificate authority
+	//
+	// Some certificate authorities may require options to be set
+	CertificateAuthorityOptions *CertificateAuthorityOptions
 	// Optional list of timestamp authorities to contact for inclusion in bundle
 	TimestampAuthorities []*TimestampAuthority
 	// Optional list of Rekor instances to get transparency log entry from.
@@ -72,8 +74,8 @@ func Bundle(content Content, keypair Keypair, opts BundleOptions) (*protobundle.
 
 	// Add verification information to bundle
 	var verifierPEM []byte
-	if opts.Certificate != nil {
-		pubKeyBytes, err := opts.Certificate.GetCertificate(opts.Context, keypair, opts.IDToken)
+	if opts.CertificateAuthority != nil {
+		pubKeyBytes, err := opts.CertificateAuthority.GetCertificate(opts.Context, keypair, opts.CertificateAuthorityOptions)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sign/signer.go
+++ b/pkg/sign/signer.go
@@ -31,15 +31,15 @@ import (
 const bundleV03MediaType = "application/vnd.dev.sigstore.bundle.v0.3+json"
 
 type BundleOptions struct {
-	// Optional certificate authority to get code signing certificate from.
+	// Optional certificate provider to get code signing certificate from.
 	//
 	// Typically a Fulcio instance; resulting bundle will contain a certificate
 	// for its verification material content instead of a public key.
-	CertificateAuthority CertificateAuthority
-	// Optional options for certificate authority
+	CertificateProvider CertificateProvider
+	// Optional options for certificate provider
 	//
 	// Some certificate authorities may require options to be set
-	CertificateAuthorityOptions *CertificateAuthorityOptions
+	CertificateProviderOptions *CertificateProviderOptions
 	// Optional list of timestamp authorities to contact for inclusion in bundle
 	TimestampAuthorities []*TimestampAuthority
 	// Optional list of Rekor instances to get transparency log entry from.
@@ -74,8 +74,8 @@ func Bundle(content Content, keypair Keypair, opts BundleOptions) (*protobundle.
 
 	// Add verification information to bundle
 	var verifierPEM []byte
-	if opts.CertificateAuthority != nil {
-		pubKeyBytes, err := opts.CertificateAuthority.GetCertificate(opts.Context, keypair, opts.CertificateAuthorityOptions)
+	if opts.CertificateProvider != nil {
+		pubKeyBytes, err := opts.CertificateProvider.GetCertificate(opts.Context, keypair, opts.CertificateProviderOptions)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sign/signer_test.go
+++ b/pkg/sign/signer_test.go
@@ -35,10 +35,4 @@ func Test_Bundle(t *testing.T) {
 	bundle, err = Bundle(content, keypair, opts)
 	assert.NotNil(t, bundle)
 	assert.Nil(t, err)
-
-	// Test requiring IDToken with Fulcio
-	opts.Fulcio = NewFulcio(&FulcioOptions{})
-	bundle, err = Bundle(content, keypair, opts)
-	assert.Nil(t, bundle)
-	assert.NotNil(t, err)
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

We are working our way down the punch list to enable signing (#136). We want the interface to be pretty stable before then, so we're making an interface for certificate authorities generally, in case someone wants to use something other than Fulcio.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

NONE - we aren't ready to release signing yet

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

N/A