### PR TITLE
Simplify HasCertificate interface method

### DIFF
--- a/pkg/bundle/verification_content.go
+++ b/pkg/bundle/verification_content.go
@@ -48,8 +48,8 @@ func (c *Certificate) ValidAtTime(t time.Time, _ root.TrustedMaterial) bool {
 	return !(c.Certificate.NotAfter.Before(t) || c.Certificate.NotBefore.After(t))
 }
 
-func (c *Certificate) HasCertificate() (x509.Certificate, bool) {
-	return *c.Certificate, true
+func (c *Certificate) GetCertificate() *x509.Certificate {
+	return c.Certificate
 }
 
 func (c *Certificate) HasPublicKey() (verify.PublicKeyProvider, bool) {
@@ -79,8 +79,8 @@ func (pk *PublicKey) ValidAtTime(t time.Time, tm root.TrustedMaterial) bool {
 	return verifier.ValidAtTime(t)
 }
 
-func (pk *PublicKey) HasCertificate() (x509.Certificate, bool) {
-	return x509.Certificate{}, false
+func (pk *PublicKey) GetCertificate() *x509.Certificate {
+	return nil
 }
 
 func (pk *PublicKey) HasPublicKey() (verify.PublicKeyProvider, bool) {

--- a/pkg/fulcio/certificate/summarize_test.go
+++ b/pkg/fulcio/certificate/summarize_test.go
@@ -30,13 +30,13 @@ func TestSummarizeCertificateWithActionsBundle(t *testing.T) {
 		t.Fatalf("failed to get verification content: %v", err)
 	}
 
-	leaf, ok := vc.HasCertificate()
+	leaf := vc.GetCertificate()
 
-	if !ok {
+	if leaf == nil {
 		t.Fatalf("expected verification content to be a certificate chain")
 	}
 
-	cs, err := certificate.SummarizeCertificate(&leaf)
+	cs, err := certificate.SummarizeCertificate(leaf)
 	if err != nil {
 		t.Fatalf("failed to summarize: %v", err)
 	}
@@ -79,13 +79,13 @@ func TestSummarizeCertificateWithOauthBundle(t *testing.T) {
 		t.Fatalf("failed to get verification content: %v", err)
 	}
 
-	leaf, ok := vc.HasCertificate()
+	leaf := vc.GetCertificate()
 
-	if !ok {
+	if leaf == nil {
 		t.Fatalf("expected verification content to be a certificate chain")
 	}
 
-	cs, err := certificate.SummarizeCertificate(&leaf)
+	cs, err := certificate.SummarizeCertificate(leaf)
 	if err != nil {
 		t.Fatalf("failed to summarize: %v", err)
 	}

--- a/pkg/verify/certificate.go
+++ b/pkg/verify/certificate.go
@@ -22,7 +22,7 @@ import (
 	"github.com/sigstore/sigstore-go/pkg/root"
 )
 
-func VerifyLeafCertificate(observerTimestamp time.Time, leafCert x509.Certificate, trustedMaterial root.TrustedMaterial) error { // nolint: revive
+func VerifyLeafCertificate(observerTimestamp time.Time, leafCert *x509.Certificate, trustedMaterial root.TrustedMaterial) error { // nolint: revive
 	for _, ca := range trustedMaterial.FulcioCertificateAuthorities() {
 		if !ca.ValidityPeriodStart.IsZero() && observerTimestamp.Before(ca.ValidityPeriodStart) {
 			continue

--- a/pkg/verify/certificate_test.go
+++ b/pkg/verify/certificate_test.go
@@ -53,7 +53,7 @@ func TestVerifyValidityPeriod(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := verify.VerifyLeafCertificate(tt.observerTimestamp, *leaf, virtualSigstore); (err != nil) != tt.wantErr {
+			if err := verify.VerifyLeafCertificate(tt.observerTimestamp, leaf, virtualSigstore); (err != nil) != tt.wantErr {
 				t.Errorf("VerifyLeafCertificate() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/pkg/verify/interface.go
+++ b/pkg/verify/interface.go
@@ -64,7 +64,7 @@ type SignedEntity interface {
 type VerificationContent interface {
 	CompareKey(any, root.TrustedMaterial) bool
 	ValidAtTime(time.Time, root.TrustedMaterial) bool
-	HasCertificate() (x509.Certificate, bool)
+	GetCertificate() *x509.Certificate
 	HasPublicKey() (PublicKeyProvider, bool)
 }
 

--- a/pkg/verify/signature.go
+++ b/pkg/verify/signature.go
@@ -89,7 +89,7 @@ func VerifySignatureWithArtifactDigest(sigContent SignatureContent, verification
 }
 
 func getSignatureVerifier(verificationContent VerificationContent, tm root.TrustedMaterial) (signature.Verifier, error) {
-	if leafCert, ok := verificationContent.HasCertificate(); ok {
+	if leafCert := verificationContent.GetCertificate(); leafCert != nil {
 		// TODO: Inspect certificate's SignatureAlgorithm to determine hash function
 		return signature.LoadVerifier(leafCert.PublicKey, crypto.SHA256)
 	} else if pk, ok := verificationContent.HasPublicKey(); ok {


### PR DESCRIPTION
Return one value instead of two, since the same information can be gleaned from the one value. Rename the method to be semantically consistent with the new signature.

Fixes https://github.com/sigstore/sigstore-go/issues/75

Used `GetCertificate` instead of `Certificate` since the struct that implements the interface already has a field named `Certificate`.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
