### PR TITLE
Improve error message when verifying certificate identity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /sigstore-go
 /tufdata
 /conformance
+/pkg/tuf/testing.local.json

--- a/pkg/fulcio/certificate/summarize_test.go
+++ b/pkg/fulcio/certificate/summarize_test.go
@@ -117,7 +117,7 @@ func TestCompareExtensions(t *testing.T) {
 	}
 
 	// Only the specified fields are expected to match
-	assert.True(t, certificate.CompareExtensions(expectedExt, actualExt))
+	assert.NoError(t, certificate.CompareExtensions(expectedExt, actualExt))
 
 	// Blank fields are ignored
 	expectedExt = certificate.Extensions{
@@ -125,7 +125,7 @@ func TestCompareExtensions(t *testing.T) {
 		GithubWorkflowName: "",
 	}
 
-	assert.True(t, certificate.CompareExtensions(expectedExt, actualExt))
+	assert.NoError(t, certificate.CompareExtensions(expectedExt, actualExt))
 
 	// but if any of the fields don't match, it should return false
 	expectedExt = certificate.Extensions{
@@ -133,5 +133,7 @@ func TestCompareExtensions(t *testing.T) {
 		GithubWorkflowName: "Final",
 	}
 
-	assert.False(t, certificate.CompareExtensions(expectedExt, actualExt))
+	errCompareExtensions := &certificate.ErrCompareExtensions{}
+	assert.ErrorAs(t, certificate.CompareExtensions(expectedExt, actualExt), &errCompareExtensions)
+	assert.Equal(t, errCompareExtensions.Error(), "expected GithubWorkflowName to be \"Final\", got \"Release\"")
 }

--- a/pkg/verify/certificate_identity_test.go
+++ b/pkg/verify/certificate_identity_test.go
@@ -99,6 +99,10 @@ func TestCertificateIdentityVerify(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "no matching CertificateIdentity found, last error: expected Issuer to be \"https://token.actions.example.com\", got \"https://token.actions.githubusercontent.com\"", err.Error())
 	assert.Nil(t, ci)
+	// test err unwrap for previous error
+	errCompareExtensions = &certificate.ErrCompareExtensions{}
+	assert.ErrorAs(t, err, &errCompareExtensions)
+	assert.Equal(t, "expected Issuer to be \"https://token.actions.example.com\", got \"https://token.actions.githubusercontent.com\"", errCompareExtensions.Error())
 
 	// if no certIDs are specified, we fail
 	_, err = CertificateIdentities{}.Verify(actualCert)

--- a/pkg/verify/certificate_identity_test.go
+++ b/pkg/verify/certificate_identity_test.go
@@ -58,36 +58,52 @@ func TestCertificateIdentityVerify(t *testing.T) {
 
 	// First, let's test happy paths:
 	issuerOnlyID, _ := certIDForTesting("", "", "", ActionsIssuerValue, "")
-	assert.True(t, issuerOnlyID.Verify(actualCert))
+	assert.NoError(t, issuerOnlyID.Verify(actualCert))
 
 	sanValueOnly, _ := certIDForTesting(SigstoreSanValue, "", "", "", "")
-	assert.True(t, sanValueOnly.Verify(actualCert))
+	assert.NoError(t, sanValueOnly.Verify(actualCert))
 
 	sanRegexOnly, _ := certIDForTesting("", "", SigstoreSanRegex, "", "")
-	assert.True(t, sanRegexOnly.Verify(actualCert))
+	assert.NoError(t, sanRegexOnly.Verify(actualCert))
 
 	// multiple values can be specified
 	sanRegexAndIssuer, _ := certIDForTesting("", "", SigstoreSanRegex, ActionsIssuerValue, "github-hosted")
-	assert.True(t, sanRegexAndIssuer.Verify(actualCert))
+	assert.NoError(t, sanRegexAndIssuer.Verify(actualCert))
 
 	// unhappy paths:
 	// wrong issuer
 	sanRegexAndWrongIssuer, _ := certIDForTesting("", "", SigstoreSanRegex, "https://token.actions.example.com", "")
-	assert.False(t, sanRegexAndWrongIssuer.Verify(actualCert))
+	errCompareExtensions := &certificate.ErrCompareExtensions{}
+	assert.ErrorAs(t, sanRegexAndWrongIssuer.Verify(actualCert), &errCompareExtensions)
+	assert.Equal(t, "expected Issuer to be \"https://token.actions.example.com\", got \"https://token.actions.githubusercontent.com\"", errCompareExtensions.Error())
+
+	// bad san regex
+	badRegex, _ := certIDForTesting("", "", "^badregex.*", "", "")
+	errSANValueRegexMismatch := &ErrSANValueRegexMismatch{}
+	assert.ErrorAs(t, badRegex.Verify(actualCert), &errSANValueRegexMismatch)
+	assert.Equal(t, "expected SAN value to match regex \"^badregex.*\", got \"https://github.com/sigstore/sigstore-js/.github/workflows/release.yml@refs/heads/main\"", errSANValueRegexMismatch.Error())
 
 	// right san value, wrong san type
+	errSANTypeMismatch := &ErrSANTypeMismatch{}
 	sanValueAndWrongType, _ := certIDForTesting(SigstoreSanValue, "DNS", "", "", "")
-	assert.False(t, sanValueAndWrongType.Verify(actualCert))
+	assert.ErrorAs(t, sanValueAndWrongType.Verify(actualCert), &errSANTypeMismatch)
+	assert.Equal(t, "expected SAN type DNS, got URI", errSANTypeMismatch.Error())
 
 	// if we have an array of certIDs, only one needs to match
 	ci, err := CertificateIdentities{sanRegexAndWrongIssuer, sanRegexAndIssuer}.Verify(actualCert)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, *ci, sanRegexAndIssuer)
 
 	// if none match, we fail
 	ci, err = CertificateIdentities{sanValueAndWrongType, sanRegexAndWrongIssuer}.Verify(actualCert)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
+	assert.Equal(t, "no matching CertificateIdentity found, last error: expected Issuer to be \"https://token.actions.example.com\", got \"https://token.actions.githubusercontent.com\"", err.Error())
 	assert.Nil(t, ci)
+
+	// if no certIDs are specified, we fail
+	_, err = CertificateIdentities{}.Verify(actualCert)
+	assert.Error(t, err)
+	assert.Equal(t, "no matching CertificateIdentity found", err.Error())
 }
 
 func TestThatCertIDsAreFullySpecified(t *testing.T) {


### PR DESCRIPTION
This modifies the API for verifying certificate identity (SAN and Extensions) to return error values instead of booleans, in order to provide a more helpful error message when the identity cannot be verified.

Fixes #89 

Signed-off-by: Cody Soyland <codysoyland@github.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
