### PR TITLE
Add the ability to specify certificate identity via a regular expression

### DIFF
--- a/cmd/conformance/main.go
+++ b/cmd/conformance/main.go
@@ -284,7 +284,7 @@ func main() {
 
 		identityPolicies := []verify.PolicyOption{}
 		if *certOIDC != "" || *certSAN != "" {
-			certID, err := verify.NewShortCertificateIdentity(*certOIDC, *certSAN, "")
+			certID, err := verify.NewShortCertificateIdentity(*certOIDC, "", *certSAN, "")
 			if err != nil {
 				fmt.Println(err)
 				os.Exit(1)
@@ -333,7 +333,7 @@ func main() {
 		// Configure verification options
 		identityPolicies := []verify.PolicyOption{}
 		if *certOIDC != "" || *certSAN != "" {
-			certID, err := verify.NewShortCertificateIdentity(*certOIDC, *certSAN, "")
+			certID, err := verify.NewShortCertificateIdentity(*certOIDC, "", *certSAN, "")
 			if err != nil {
 				fmt.Println(err)
 				os.Exit(1)

--- a/cmd/sigstore-go/main.go
+++ b/cmd/sigstore-go/main.go
@@ -41,6 +41,7 @@ var artifact *string
 var artifactDigest *string
 var artifactDigestAlgorithm *string
 var expectedOIDIssuer *string
+var expectedOIDIssuerRegex *string
 var expectedSAN *string
 var expectedSANRegex *string
 var requireTimestamp *bool
@@ -58,6 +59,7 @@ func init() {
 	artifactDigest = flag.String("artifact-digest", "", "Hex-encoded digest of artifact to verify")
 	artifactDigestAlgorithm = flag.String("artifact-digest-algorithm", "sha256", "Digest algorithm")
 	expectedOIDIssuer = flag.String("expectedIssuer", "", "The expected OIDC issuer for the signing certificate")
+	expectedOIDIssuerRegex = flag.String("expectedIssuerRegex", "", "The expected OIDC issuer for the signing certificate")
 	expectedSAN = flag.String("expectedSAN", "", "The expected identity in the signing certificate's SAN extension")
 	expectedSANRegex = flag.String("expectedSANRegex", "", "The expected identity in the signing certificate's SAN extension")
 	requireTimestamp = flag.Bool("requireTimestamp", true, "Require either an RFC3161 signed timestamp or log entry integrated timestamp")
@@ -120,7 +122,7 @@ func run() error {
 		verifierConfig = append(verifierConfig, verify.WithOnlineVerification())
 	}
 
-	certID, err := verify.NewShortCertificateIdentity(*expectedOIDIssuer, "", *expectedSAN, *expectedSANRegex)
+	certID, err := verify.NewShortCertificateIdentity(*expectedOIDIssuer, *expectedOIDIssuerRegex, *expectedSAN, *expectedSANRegex)
 	if err != nil {
 		return err
 	}

--- a/cmd/sigstore-go/main.go
+++ b/cmd/sigstore-go/main.go
@@ -120,7 +120,7 @@ func run() error {
 		verifierConfig = append(verifierConfig, verify.WithOnlineVerification())
 	}
 
-	certID, err := verify.NewShortCertificateIdentity(*expectedOIDIssuer, *expectedSAN, *expectedSANRegex)
+	certID, err := verify.NewShortCertificateIdentity(*expectedOIDIssuer, "", *expectedSAN, *expectedSANRegex)
 	if err != nil {
 		return err
 	}

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -95,7 +95,7 @@ Then, we need to prepare the expected artifact digest. Note that this option has
 In this case, we also need to prepare the expected certificate identity. Note that this option has an alternative option `WithoutIdentitiesUnsafe`. This is a failsafe to ensure that the caller is aware that simply verifying the bundle is not enough, you must also verify the contents of the bundle against a specific identity. If your bundle was signed with a key, and thus does not have a certificate identity, a better choice is to use the `WithKey` option.
 
 ```go
-	certID, err := verify.NewShortCertificateIdentity("https://token.actions.githubusercontent.com", "", "^https://github.com/sigstore/sigstore-js/")
+	certID, err := verify.NewShortCertificateIdentity("https://token.actions.githubusercontent.com", "", "", "^https://github.com/sigstore/sigstore-js/")
 	if err != nil {
 		panic(err)
 	}
@@ -221,7 +221,7 @@ func main() {
 		panic(err)
 	}
 
-	certID, err := verify.NewShortCertificateIdentity("https://token.actions.githubusercontent.com", "", "^https://github.com/sigstore/sigstore-js/")
+	certID, err := verify.NewShortCertificateIdentity("https://token.actions.githubusercontent.com", "", "", "^https://github.com/sigstore/sigstore-js/")
 	if err != nil {
 		panic(err)
 	}

--- a/examples/oci-image-verification/main.go
+++ b/examples/oci-image-verification/main.go
@@ -134,7 +134,7 @@ func run() error {
 	}
 
 	if *expectedOIDIssuer != "" || *expectedSAN != "" || *expectedSANRegex != "" {
-		certID, err := verify.NewShortCertificateIdentity(*expectedOIDIssuer, *expectedSAN, *expectedSANRegex)
+		certID, err := verify.NewShortCertificateIdentity(*expectedOIDIssuer, "", *expectedSAN, *expectedSANRegex)
 		if err != nil {
 			return err
 		}

--- a/examples/oci-image-verification/main.go
+++ b/examples/oci-image-verification/main.go
@@ -48,6 +48,7 @@ var artifact *string
 var artifactDigest *string
 var artifactDigestAlgorithm *string
 var expectedOIDIssuer *string
+var expectedOIDIssuerRegex *string
 var expectedSAN *string
 var expectedSANRegex *string
 var requireTimestamp *bool
@@ -65,6 +66,7 @@ func init() {
 	artifactDigest = flag.String("artifact-digest", "", "Hex-encoded digest of artifact to verify")
 	artifactDigestAlgorithm = flag.String("artifact-digest-algorithm", "sha256", "Digest algorithm")
 	expectedOIDIssuer = flag.String("expectedIssuer", "", "The expected OIDC issuer for the signing certificate")
+	expectedOIDIssuerRegex = flag.String("expectedIssuerRegex", "", "The expected OIDC issuer for the signing certificate")
 	expectedSAN = flag.String("expectedSAN", "", "The expected identity in the signing certificate's SAN extension")
 	expectedSANRegex = flag.String("expectedSANRegex", "", "The expected identity in the signing certificate's SAN extension")
 	requireTimestamp = flag.Bool("requireTimestamp", true, "Require either an RFC3161 signed timestamp or log entry integrated timestamp")
@@ -133,8 +135,8 @@ func run() error {
 		verifierConfig = append(verifierConfig, verify.WithOnlineVerification())
 	}
 
-	if *expectedOIDIssuer != "" || *expectedSAN != "" || *expectedSANRegex != "" {
-		certID, err := verify.NewShortCertificateIdentity(*expectedOIDIssuer, "", *expectedSAN, *expectedSANRegex)
+	if *expectedOIDIssuer != "" || *expectedOIDIssuerRegex != "" || *expectedSAN != "" || *expectedSANRegex != "" {
+		certID, err := verify.NewShortCertificateIdentity(*expectedOIDIssuer, *expectedOIDIssuerRegex, *expectedSAN, *expectedSANRegex)
 		if err != nil {
 			return err
 		}

--- a/pkg/verify/signed_entity_test.go
+++ b/pkg/verify/signed_entity_test.go
@@ -210,7 +210,7 @@ func TestEntityWithOthernameSan(t *testing.T) {
 	digest, err := hex.DecodeString("bc103b4a84971ef6459b294a2b98568a2bfb72cded09d4acd1e16366a401f95b")
 	assert.NoError(t, err)
 
-	certID, err := verify.NewShortCertificateIdentity("http://oidc.local:8080", "foo!oidc.local", "")
+	certID, err := verify.NewShortCertificateIdentity("http://oidc.local:8080", "", "foo!oidc.local", "")
 	assert.NoError(t, err)
 	res, err := v.Verify(entity, verify.NewPolicy(verify.WithArtifactDigest("sha256", digest), verify.WithCertificateIdentity(certID)))
 	assert.NoError(t, err)
@@ -220,7 +220,7 @@ func TestEntityWithOthernameSan(t *testing.T) {
 	assert.Equal(t, res.VerifiedIdentity.SubjectAlternativeName.SubjectAlternativeName, "foo!oidc.local")
 
 	// an email address doesn't verify
-	certID, err = verify.NewShortCertificateIdentity("http://oidc.local:8080", "foo@oidc.local", "")
+	certID, err = verify.NewShortCertificateIdentity("http://oidc.local:8080", "", "foo@oidc.local", "")
 	assert.NoError(t, err)
 	_, err = v.Verify(entity, verify.NewPolicy(verify.WithArtifactDigest("sha256", digest), verify.WithCertificateIdentity(certID)))
 	assert.Error(t, err)
@@ -235,7 +235,7 @@ func TestVerifyPolicyOptionErors(t *testing.T) {
 	verifier, err := verify.NewSignedEntityVerifier(tr, verify.WithTransparencyLog(1), verify.WithObserverTimestamps(1))
 	assert.Nil(t, err)
 
-	goodCertID, err := verify.NewShortCertificateIdentity(verify.ActionsIssuerValue, "", verify.SigstoreSanRegex)
+	goodCertID, err := verify.NewShortCertificateIdentity(verify.ActionsIssuerValue, "", "", verify.SigstoreSanRegex)
 	assert.Nil(t, err)
 
 	digest, _ := hex.DecodeString("46d4e2f74c4877316640000a6fdf8a8b59f1e0847667973e9859f774dd31b8f1e0937813b777fb66a2ac67d50540fe34640966eee9fc2ccca387082b4c85cd3c")
@@ -326,8 +326,8 @@ func TestEntitySignedByPublicGoodWithCertificateIdentityVerifiesSuccessfully(t *
 	tr := data.PublicGoodTrustedMaterialRoot(t)
 	entity := data.SigstoreJS200ProvenanceBundle(t)
 
-	goodCI, _ := verify.NewShortCertificateIdentity(verify.ActionsIssuerValue, "", verify.SigstoreSanRegex)
-	badCI, _ := verify.NewShortCertificateIdentity(verify.ActionsIssuerValue, "BadSANValue", "")
+	goodCI, _ := verify.NewShortCertificateIdentity(verify.ActionsIssuerValue, "", "", verify.SigstoreSanRegex)
+	badCI, _ := verify.NewShortCertificateIdentity(verify.ActionsIssuerValue, "", "BadSANValue", "")
 
 	verifier, err := verify.NewSignedEntityVerifier(tr, verify.WithTransparencyLog(1), verify.WithObserverTimestamps(1))
 

--- a/pkg/verify/signed_entity_test.go
+++ b/pkg/verify/signed_entity_test.go
@@ -216,7 +216,7 @@ func TestEntityWithOthernameSan(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, res)
 
-	assert.Equal(t, res.VerifiedIdentity.Issuer, "http://oidc.local:8080")
+	assert.Equal(t, res.VerifiedIdentity.Issuer.Issuer, "http://oidc.local:8080")
 	assert.Equal(t, res.VerifiedIdentity.SubjectAlternativeName.SubjectAlternativeName, "foo!oidc.local")
 
 	// an email address doesn't verify
@@ -342,7 +342,7 @@ func TestEntitySignedByPublicGoodWithCertificateIdentityVerifiesSuccessfully(t *
 			verify.WithCertificateIdentity(goodCI)))
 	assert.Nil(t, err)
 
-	assert.Equal(t, res.VerifiedIdentity.Issuer, verify.ActionsIssuerValue)
+	assert.Equal(t, res.VerifiedIdentity.Issuer.Issuer, verify.ActionsIssuerValue)
 
 	// but if only pass in the bad CI, it will fail:
 	res, err = verifier.Verify(entity,


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Fixes #234

Cosign allows you to verify bundles signed with a certificate by providing a regular expression to match the certificate identity. Previously, sigstore-go required you to specify the exact certificate identity. This change adds support for sigstore-go to match the certificate identity with a regular expression.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

* Allows specifying certificate identity with a regular expression, for verifying bundles
* Breaking change: additional string argument to `verify.NewShortCertificateIdentity()` and `verify.NewCertificateIdentity()`

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

N/A