### PR TITLE
`NewIssuserMatcher` should be `NewIssuerMatcher`

### DIFF
--- a/pkg/verify/certificate_identity.go
+++ b/pkg/verify/certificate_identity.go
@@ -115,7 +115,7 @@ func (s SubjectAlternativeNameMatcher) Verify(actualCert certificate.Summary) er
 	return nil
 }
 
-func NewIssuserMatcher(issuerValue, regexpStr string) (IssuerMatcher, error) {
+func NewIssuerMatcher(issuerValue, regexpStr string) (IssuerMatcher, error) {
 	r, err := regexp.Compile(regexpStr)
 	if err != nil {
 		return IssuerMatcher{}, err
@@ -178,7 +178,7 @@ func NewShortCertificateIdentity(issuer, issuerRegex, sanValue, sanRegex string)
 		return CertificateIdentity{}, err
 	}
 
-	issuerMatcher, err := NewIssuserMatcher(issuer, issuerRegex)
+	issuerMatcher, err := NewIssuerMatcher(issuer, issuerRegex)
 	if err != nil {
 		return CertificateIdentity{}, err
 	}

--- a/pkg/verify/certificate_identity_test.go
+++ b/pkg/verify/certificate_identity_test.go
@@ -138,7 +138,7 @@ func certIDForTesting(sanValue, sanRegex, issuer, issuerRegex, runnerEnv string)
 		return CertificateIdentity{}, err
 	}
 
-	issuerMatcher, err := NewIssuserMatcher(issuer, issuerRegex)
+	issuerMatcher, err := NewIssuerMatcher(issuer, issuerRegex)
 	if err != nil {
 		return CertificateIdentity{}, err
 	}


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

As I went to make a pull request to update https://github.com/cli/cli I noticed I misspelled this function name 😞 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

N/A