### PR TITLE
handle case insensitivity for compare extensions

### DIFF
--- a/pkg/fulcio/certificate/summarize.go
+++ b/pkg/fulcio/certificate/summarize.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 )
@@ -79,8 +80,17 @@ func CompareExtensions(expectedExt, actualExt Extensions) error {
 		if expectedFieldVal.IsValid() && !expectedFieldVal.IsZero() {
 			actualFieldVal := actExtValue.FieldByName(field.Name)
 			if actualFieldVal.IsValid() {
-				if expectedFieldVal.Interface() != actualFieldVal.Interface() {
-					return &ErrCompareExtensions{field.Name, fmt.Sprintf("%v", expectedFieldVal.Interface()), fmt.Sprintf("%v", actualFieldVal.Interface())}
+				expectedInterface := expectedFieldVal.Interface()
+				actualInterface := actualFieldVal.Interface()
+
+				if expectedFieldVal.Kind() == reflect.String && actualFieldVal.Kind() == reflect.String {
+					expectedStr := expectedFieldVal.String()
+					actualStr := actualFieldVal.String()
+					if !strings.EqualFold(expectedStr, actualStr) {
+						return &ErrCompareExtensions{field.Name, expectedStr, actualStr}
+					}
+				} else if expectedInterface != actualInterface {
+					return &ErrCompareExtensions{field.Name, fmt.Sprintf("%v", expectedInterface), fmt.Sprintf("%v", actualInterface)}
 				}
 			}
 		}


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

ref: https://github.com/sigstore/sigstore-go/issues/89

This modifies the API for verifying certificate identity (SAN and Extensions) to turn CompareExtensions case insensitivity in order to handle cases that `OIDSourceRepositoryURI` or other fields can have different cases. 

Signed-off-by: Eugene Jahn [ejahngithub@github.com](mailto:ejahngithub@github.com)


<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
