### PR TITLE
Fix verify DSSE bundles (after signing)

### DIFF
--- a/pkg/sign/signer.go
+++ b/pkg/sign/signer.go
@@ -15,7 +15,6 @@
 package sign
 
 import (
-	"bytes"
 	"context"
 	"encoding/pem"
 	"errors"
@@ -149,7 +148,7 @@ func Bundle(content Content, keypair Keypair, opts BundleOptions) (*protobundle.
 			return nil, err
 		}
 
-		artifactOpts := verify.WithArtifact(bytes.NewReader(content.PreAuthEncoding()))
+		artifactOpts := verify.WithoutArtifactUnsafe()
 		policy := verify.NewPolicy(artifactOpts, verify.WithoutIdentitiesUnsafe())
 		_, err = sev.Verify(protobundle, policy)
 		if err != nil {

--- a/pkg/sign/signer.go
+++ b/pkg/sign/signer.go
@@ -15,6 +15,7 @@
 package sign
 
 import (
+	"bytes"
 	"context"
 	"encoding/pem"
 	"errors"
@@ -148,7 +149,15 @@ func Bundle(content Content, keypair Keypair, opts BundleOptions) (*protobundle.
 			return nil, err
 		}
 
+		// Generally, you should provide an artifact when verifying.
+		//
+		// However, we just signed the DSSE object trusting the user has
+		// referenced the artifact(s) they intended.
 		artifactOpts := verify.WithoutArtifactUnsafe()
+		if bundle.GetMessageSignature() != nil {
+			artifactOpts = verify.WithArtifact(bytes.NewReader(content.PreAuthEncoding()))
+		}
+
 		policy := verify.NewPolicy(artifactOpts, verify.WithoutIdentitiesUnsafe())
 		_, err = sev.Verify(protobundle, policy)
 		if err != nil {


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Fixes #257.

When signing, if you optionally supply a trusted root we will attempt to verify the bundle before we return it.

Previously we were using the wrong artifact digest for DSSE signing. We could add a way to specify the artifact referred to in DSSE, but we are already trusting the certificate identity in the user-supplied id token.

You can test with something like this (which previously would fail):

```
$ go run examples/sigstore-go-signing/main.go -id-token "..." -in-toto -rekor examples/sigstore-go-signing/intoto.txt 
```

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

N/A