### PR TITLE
Include URI for CA verified timestamps

### DIFF
--- a/pkg/root/trusted_root.go
+++ b/pkg/root/trusted_root.go
@@ -279,7 +279,9 @@ func ParseCertificateAuthority(certAuthority *prototrustroot.CertificateAuthorit
 		}
 	}
 
-	// TODO: Should we inspect/enforce ca.Subject and ca.Uri?
+	certificateAuthority.URI = certAuthority.Uri
+
+	// TODO: Should we inspect/enforce ca.Subject?
 	// TODO: Handle validity period (ca.ValidFor)
 
 	return certificateAuthority, nil

--- a/pkg/verify/signed_entity.go
+++ b/pkg/verify/signed_entity.go
@@ -667,7 +667,7 @@ func (v *SignedEntityVerifier) VerifyTransparencyLogInclusion(entity SignedEntit
 		}
 
 		for _, vts := range verifiedTlogTimestamps {
-			verifiedTimestamps = append(verifiedTimestamps, TimestampVerificationResult{Type: "Tlog", URI: "TODO", Timestamp: vts})
+			verifiedTimestamps = append(verifiedTimestamps, TimestampVerificationResult{Type: "Tlog", URI: vts.URI, Timestamp: vts.Time})
 		}
 	}
 
@@ -692,7 +692,7 @@ func (v *SignedEntityVerifier) VerifyObserverTimestamps(entity SignedEntity, log
 			return nil, err
 		}
 		for _, vts := range verifiedSignedTimestamps {
-			verifiedTimestamps = append(verifiedTimestamps, TimestampVerificationResult{Type: "TimestampAuthority", URI: "TODO", Timestamp: vts})
+			verifiedTimestamps = append(verifiedTimestamps, TimestampVerificationResult{Type: "TimestampAuthority", URI: vts.URI, Timestamp: vts.Time})
 		}
 	}
 
@@ -719,7 +719,7 @@ func (v *SignedEntityVerifier) VerifyObserverTimestamps(entity SignedEntity, log
 		// append all timestamps
 		verifiedTimestamps = append(verifiedTimestamps, logTimestamps...)
 		for _, vts := range verifiedSignedTimestamps {
-			verifiedTimestamps = append(verifiedTimestamps, TimestampVerificationResult{Type: "TimestampAuthority", URI: "TODO", Timestamp: vts})
+			verifiedTimestamps = append(verifiedTimestamps, TimestampVerificationResult{Type: "TimestampAuthority", URI: vts.URI, Timestamp: vts.Time})
 		}
 	}
 

--- a/pkg/verify/signed_entity_test.go
+++ b/pkg/verify/signed_entity_test.go
@@ -94,6 +94,7 @@ func TestEntitySignedByPublicGoodWithTlogVerifiesSuccessfully(t *testing.T) {
 	assert.NotNil(t, res.Signature.Certificate)
 	assert.Equal(t, "https://github.com/sigstore/sigstore-js/.github/workflows/release.yml@refs/heads/main", res.Signature.Certificate.SubjectAlternativeName)
 	assert.NotEmpty(t, res.VerifiedTimestamps)
+	assert.Equal(t, "https://rekor.sigstore.dev", res.VerifiedTimestamps[0].URI)
 
 	// verifies with integrated timestamp threshold too
 	v, err = verify.NewSignedEntityVerifier(tr, verify.WithTransparencyLog(1), verify.WithIntegratedTimestamps(1))

--- a/pkg/verify/tlog.go
+++ b/pkg/verify/tlog.go
@@ -21,7 +21,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"time"
 
 	rekorClient "github.com/sigstore/rekor/pkg/client"
 	rekorGeneratedClient "github.com/sigstore/rekor/pkg/generated/client"
@@ -43,7 +42,7 @@ const maxAllowedTlogEntries = 32
 // that must be verified.
 //
 // If online is true, the log entry is verified against the Rekor server.
-func VerifyArtifactTransparencyLog(entity SignedEntity, trustedMaterial root.TrustedMaterial, logThreshold int, trustIntegratedTime, online bool) ([]time.Time, error) { //nolint:revive
+func VerifyArtifactTransparencyLog(entity SignedEntity, trustedMaterial root.TrustedMaterial, logThreshold int, trustIntegratedTime, online bool) ([]Timestamp, error) { //nolint:revive
 	entries, err := entity.TlogEntries()
 	if err != nil {
 		return nil, err
@@ -75,7 +74,7 @@ func VerifyArtifactTransparencyLog(entity SignedEntity, trustedMaterial root.Tru
 		return nil, err
 	}
 
-	verifiedTimestamps := []time.Time{}
+	verifiedTimestamps := []Timestamp{}
 	logEntriesVerified := 0
 
 	for _, entry := range entries {
@@ -84,29 +83,29 @@ func VerifyArtifactTransparencyLog(entity SignedEntity, trustedMaterial root.Tru
 			return nil, err
 		}
 
+		rekorLogs := trustedMaterial.RekorLogs()
+		keyID := entry.LogKeyID()
+		hex64Key := hex.EncodeToString([]byte(keyID))
+		tlogVerifier, ok := trustedMaterial.RekorLogs()[hex64Key]
+		if !ok {
+			// skip entries the trust root cannot verify
+			continue
+		}
 		if !online {
 			if !entry.HasInclusionPromise() && !entry.HasInclusionProof() {
 				return nil, fmt.Errorf("entry must contain an inclusion proof and/or promise")
 			}
 			if entry.HasInclusionPromise() {
-				err = tlog.VerifySET(entry, trustedMaterial.RekorLogs())
+				err = tlog.VerifySET(entry, rekorLogs)
 				if err != nil {
 					// skip entries the trust root cannot verify
 					continue
 				}
 				if trustIntegratedTime {
-					verifiedTimestamps = append(verifiedTimestamps, entry.IntegratedTime())
+					verifiedTimestamps = append(verifiedTimestamps, Timestamp{Time: entry.IntegratedTime(), URI: tlogVerifier.BaseURL})
 				}
 			}
 			if entity.HasInclusionProof() {
-				keyID := entry.LogKeyID()
-				hex64Key := hex.EncodeToString([]byte(keyID))
-				tlogVerifier, ok := trustedMaterial.RekorLogs()[hex64Key]
-				if !ok {
-					// skip entries the trust root cannot verify
-					continue
-				}
-
 				verifier, err := getVerifier(tlogVerifier.PublicKey, tlogVerifier.SignatureHashFunc)
 				if err != nil {
 					return nil, err
@@ -119,14 +118,6 @@ func VerifyArtifactTransparencyLog(entity SignedEntity, trustedMaterial root.Tru
 				// DO NOT use timestamp with only an inclusion proof, because it is not signed metadata
 			}
 		} else {
-			keyID := entry.LogKeyID()
-			hex64Key := hex.EncodeToString([]byte(keyID))
-			tlogVerifier, ok := trustedMaterial.RekorLogs()[hex64Key]
-			if !ok {
-				// skip entries the trust root cannot verify
-				continue
-			}
-
 			client, err := getRekorClient(tlogVerifier.BaseURL)
 			if err != nil {
 				return nil, err
@@ -160,7 +151,7 @@ func VerifyArtifactTransparencyLog(entity SignedEntity, trustedMaterial root.Tru
 				}
 			}
 			if trustIntegratedTime {
-				verifiedTimestamps = append(verifiedTimestamps, entry.IntegratedTime())
+				verifiedTimestamps = append(verifiedTimestamps, Timestamp{Time: entry.IntegratedTime(), URI: tlogVerifier.BaseURL})
 			}
 		}
 		// Ensure entry signature matches signature from bundle

--- a/pkg/verify/tlog_test.go
+++ b/pkg/verify/tlog_test.go
@@ -35,7 +35,7 @@ func TestTlogVerifier(t *testing.T) {
 	entity, err := virtualSigstore.Attest("foo@example.com", "issuer", statement)
 	assert.NoError(t, err)
 
-	var ts []time.Time
+	var ts []verify.Timestamp
 	ts, err = verify.VerifyArtifactTransparencyLog(entity, virtualSigstore, 1, true, false)
 	assert.NoError(t, err)
 	// 1 verified timestamp

--- a/pkg/verify/tsa_test.go
+++ b/pkg/verify/tsa_test.go
@@ -60,7 +60,7 @@ func TestTimestampAuthorityVerifierWithoutThreshold(t *testing.T) {
 	virtualSigstore2, err := ca.NewVirtualSigstore()
 	assert.NoError(t, err)
 
-	var ts []time.Time
+	var ts []verify.Timestamp
 
 	// expect one verified timestamp
 	ts, err = verify.VerifyTimestampAuthority(entity, virtualSigstore)


### PR DESCRIPTION
Include the URI of the transparency log and timestamp authority for
verified timestamps in the final verification result. The URIs are
helpful for human readability of the result.

When the WithoutAnyObserverTimestampsUnsafe verify policy is selected,
there is no certificate authority, so the URI is left empty.

Fixes https://github.com/sigstore/sigstore-go/issues/193

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
