### PR TITLE
Verify certificate validity with only current time, bump conformance tests

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -42,11 +42,11 @@ jobs:
 
       - run: go build -o conformance cmd/conformance/main.go
 
-      - uses: sigstore/sigstore-conformance@6bd1c54e236c9517da56f7344ad16cc00439fe19 # v0.0.13
+      - uses: sigstore/sigstore-conformance@b0635d4101f11dbd18a50936568a1f7f55b17760 # v0.0.14
         with:
           entrypoint: ${{ github.workspace }}/conformance
 
-      - uses: sigstore/sigstore-conformance@6bd1c54e236c9517da56f7344ad16cc00439fe19 # v0.0.13
+      - uses: sigstore/sigstore-conformance@b0635d4101f11dbd18a50936568a1f7f55b17760 # v0.0.14
         with:
           entrypoint: ${{ github.workspace }}/conformance
           environment: staging

--- a/cmd/conformance/main.go
+++ b/cmd/conformance/main.go
@@ -299,7 +299,7 @@ func main() {
 		tr := getTrustedRoot(staging)
 
 		verifierConfig := []verify.VerifierOption{}
-		verifierConfig = append(verifierConfig, verify.WithoutAnyObserverTimestampsUnsafe(), verify.WithSignedCertificateTimestamps(1))
+		verifierConfig = append(verifierConfig, verify.WithCurrentTime(), verify.WithSignedCertificateTimestamps(1))
 
 		// Verify bundle
 		sev, err := verify.NewSignedEntityVerifier(tr, verifierConfig...)

--- a/pkg/verify/signed_entity.go
+++ b/pkg/verify/signed_entity.go
@@ -38,9 +38,9 @@ type SignedEntityVerifier struct {
 }
 
 type VerifierConfig struct { // nolint: revive
-	// weExpectSignedTimestamps requires RFC3161 timestamps to verify
+	// requireSignedTimestamps requires RFC3161 timestamps to verify
 	// short-lived certificates
-	weExpectSignedTimestamps bool
+	requireSignedTimestamps bool
 	// signedTimestampThreshold is the minimum number of verified
 	// RFC3161 timestamps in a bundle
 	signedTimestampThreshold int
@@ -56,20 +56,19 @@ type VerifierConfig struct { // nolint: revive
 	// observerTimestampThreshold is the minimum number of verified
 	// RFC3161 timestamps and/or log integrated timestamps in a bundle
 	observerTimestampThreshold int
-	// weExpectTlogEntries requires log inclusion proofs in a bundle
-	weExpectTlogEntries bool
+	// requireTlogEntries requires log inclusion proofs in a bundle
+	requireTlogEntries bool
 	// tlogEntriesThreshold is the minimum number of verified inclusion
 	// proofs in a bundle
 	tlogEntriesThreshold int
-	// weExpectSCTs requires SCTs in Fulcio certificates
-	weExpectSCTs bool
+	// requireSCTs requires SCTs in Fulcio certificates
+	requireSCTs bool
 	// ctlogEntriesTreshold is the minimum number of verified SCTs in
 	// a Fulcio certificate
 	ctlogEntriesThreshold int
-	// weDoNotExpectAnyObserverTimestamps uses the certificate's lifetime
-	// rather than a provided signed or log timestamp. Most workflows will
-	// not use this option
-	weDoNotExpectAnyObserverTimestamps bool
+	// useCurrentTime uses the current time rather than a provided signed
+	// or log timestamp. Most workflows will not use this option
+	useCurrentTime bool
 }
 
 type VerifierOption func(*VerifierConfig) error
@@ -115,7 +114,7 @@ func WithSignedTimestamps(threshold int) VerifierOption {
 		if threshold < 1 {
 			return errors.New("signed timestamp threshold must be at least 1")
 		}
-		c.weExpectSignedTimestamps = true
+		c.requireSignedTimestamps = true
 		c.signedTimestampThreshold = threshold
 		return nil
 	}
@@ -145,7 +144,7 @@ func WithTransparencyLog(threshold int) VerifierOption {
 		if threshold < 1 {
 			return errors.New("transparency log entry threshold must be at least 1")
 		}
-		c.weExpectTlogEntries = true
+		c.requireTlogEntries = true
 		c.tlogEntriesThreshold = threshold
 		return nil
 	}
@@ -170,30 +169,26 @@ func WithSignedCertificateTimestamps(threshold int) VerifierOption {
 		if threshold < 1 {
 			return errors.New("ctlog entry threshold must be at least 1")
 		}
-		c.weExpectSCTs = true
+		c.requireSCTs = true
 		c.ctlogEntriesThreshold = threshold
 		return nil
 	}
 }
 
-// WithoutAnyObserverTimestampsUnsafe configures the SignedEntityVerifier to not expect
+// WithCurrentTime configures the SignedEntityVerifier to not expect
 // any timestamps from either a Timestamp Authority or a Transparency Log.
-//
-// A SignedEntity without a trusted "observer" timestamp to verify the attached
-// Fulcio certificate can't provide the same kind of integrity guarantee.
-//
-// Do not enable this if you don't know what you are doing; as the name implies,
-// using it defeats part of the security guarantees offered by Sigstore. This
-// option is only useful for testing.
-func WithoutAnyObserverTimestampsUnsafe() VerifierOption {
+// This option should not be enabled when verifying short-lived certificates,
+// as an observer timestamp is needed. This option is useful primarily for
+// private deployments with long-lived code signing certificates.
+func WithCurrentTime() VerifierOption {
 	return func(c *VerifierConfig) error {
-		c.weDoNotExpectAnyObserverTimestamps = true
+		c.useCurrentTime = true
 		return nil
 	}
 }
 
 func (c *VerifierConfig) Validate() error {
-	if !c.requireObserverTimestamps && !c.weExpectSignedTimestamps && !c.requireIntegratedTimestamps && !c.weDoNotExpectAnyObserverTimestamps {
+	if !c.requireObserverTimestamps && !c.requireSignedTimestamps && !c.requireIntegratedTimestamps && !c.useCurrentTime {
 		return errors.New("when initializing a new SignedEntityVerifier, you must specify at least one of " +
 			"WithObserverTimestamps(), WithSignedTimestamps(), WithIntegratedTimestamps(), or WithoutAnyObserverTimestampsUnsafe()")
 	}
@@ -552,7 +547,7 @@ func (v *SignedEntityVerifier) Verify(entity SignedEntity, pb PolicyBuilder) (*V
 		// From spec:
 		// > Unless performing online verification (see §Alternative Workflows), the Verifier MUST extract the  SignedCertificateTimestamp embedded in the leaf certificate, and verify it as in RFC 9162 §8.1.3, using the verification key from the Certificate Transparency Log.
 
-		if v.config.weExpectSCTs {
+		if v.config.requireSCTs {
 			err = VerifySignedCertificateTimestamp(chains, v.config.ctlogEntriesThreshold, v.trustedMaterial)
 			if err != nil {
 				return nil, fmt.Errorf("failed to verify signed certificate timestamp: %w", err)
@@ -647,7 +642,7 @@ func (v *SignedEntityVerifier) Verify(entity SignedEntity, pb PolicyBuilder) (*V
 func (v *SignedEntityVerifier) VerifyTransparencyLogInclusion(entity SignedEntity) ([]TimestampVerificationResult, error) {
 	verifiedTimestamps := []TimestampVerificationResult{}
 
-	if v.config.weExpectTlogEntries {
+	if v.config.requireTlogEntries {
 		// log timestamps should be verified if with WithIntegratedTimestamps or WithObserverTimestamps is used
 		verifiedTlogTimestamps, err := VerifyArtifactTransparencyLog(entity, v.trustedMaterial, v.config.tlogEntriesThreshold,
 			v.config.requireIntegratedTimestamps || v.config.requireObserverTimestamps)
@@ -675,7 +670,7 @@ func (v *SignedEntityVerifier) VerifyObserverTimestamps(entity SignedEntity, log
 
 	// From spec:
 	// > … if verification or timestamp parsing fails, the Verifier MUST abort
-	if v.config.weExpectSignedTimestamps {
+	if v.config.requireSignedTimestamps {
 		verifiedSignedTimestamps, err := VerifyTimestampAuthorityWithThreshold(entity, v.trustedMaterial, v.config.signedTimestampThreshold)
 		if err != nil {
 			return nil, err
@@ -712,7 +707,7 @@ func (v *SignedEntityVerifier) VerifyObserverTimestamps(entity SignedEntity, log
 		}
 	}
 
-	if v.config.weDoNotExpectAnyObserverTimestamps {
+	if v.config.useCurrentTime {
 		// use current time to verify certificate if no signed timestamps are provided
 		verifiedTimestamps = append(verifiedTimestamps, TimestampVerificationResult{Type: "CurrentTime", URI: "", Timestamp: time.Now()})
 	}

--- a/pkg/verify/signed_entity.go
+++ b/pkg/verify/signed_entity.go
@@ -713,18 +713,8 @@ func (v *SignedEntityVerifier) VerifyObserverTimestamps(entity SignedEntity, log
 	}
 
 	if v.config.weDoNotExpectAnyObserverTimestamps {
-		// if we have a cert, let's pop the leafcert's NotBefore
-		verificationContent, err := entity.VerificationContent()
-		if err != nil {
-			return nil, err
-		}
-
-		if leafCert := verificationContent.Certificate(); leafCert != nil {
-			verifiedTimestamps = append(verifiedTimestamps, TimestampVerificationResult{Type: "LeafCert.NotBefore", URI: "", Timestamp: leafCert.NotBefore})
-		} else {
-			// no cert? use current time
-			verifiedTimestamps = append(verifiedTimestamps, TimestampVerificationResult{Type: "CurrentTime", URI: "", Timestamp: time.Now()})
-		}
+		// use current time to verify certificate if no signed timestamps are provided
+		verifiedTimestamps = append(verifiedTimestamps, TimestampVerificationResult{Type: "CurrentTime", URI: "", Timestamp: time.Now()})
 	}
 
 	if len(verifiedTimestamps) == 0 {

--- a/pkg/verify/signed_entity_test.go
+++ b/pkg/verify/signed_entity_test.go
@@ -108,7 +108,7 @@ func TestEntitySignedByPublicGoodWithoutTimestampsVerifiesSuccessfully(t *testin
 	tr := data.PublicGoodTrustedMaterialRoot(t)
 	entity := data.SigstoreJS200ProvenanceBundle(t)
 
-	v, err := verify.NewSignedEntityVerifier(tr, verify.WithoutAnyObserverTimestampsUnsafe())
+	v, err := verify.NewSignedEntityVerifier(tr, verify.WithTransparencyLog(1), verify.WithIntegratedTimestamps(1))
 	assert.NoError(t, err)
 
 	res, err := v.Verify(entity, SkipArtifactAndIdentitiesPolicy)
@@ -205,7 +205,7 @@ func TestEntityWithOthernameSan(t *testing.T) {
 	tr := data.ScaffoldingTrustedMaterialRoot(t)
 	entity := data.OthernameBundle(t)
 
-	v, err := verify.NewSignedEntityVerifier(tr, verify.WithoutAnyObserverTimestampsUnsafe())
+	v, err := verify.NewSignedEntityVerifier(tr, verify.WithTransparencyLog(1), verify.WithIntegratedTimestamps(1))
 	assert.NoError(t, err)
 
 	digest, err := hex.DecodeString("bc103b4a84971ef6459b294a2b98568a2bfb72cded09d4acd1e16366a401f95b")

--- a/pkg/verify/signed_entity_test.go
+++ b/pkg/verify/signed_entity_test.go
@@ -40,7 +40,7 @@ func TestSignedEntityVerifierInitialization(t *testing.T) {
 	assert.Nil(t, err)
 
 	// unless we are really sure we want a verifier without either tlog or tsa
-	_, err = verify.NewSignedEntityVerifier(tr, verify.WithoutAnyObserverTimestampsUnsafe())
+	_, err = verify.NewSignedEntityVerifier(tr, verify.WithCurrentTime())
 	assert.Nil(t, err)
 
 	// can configure the verifiers with thresholds
@@ -68,7 +68,7 @@ func TestSignedEntityVerifierInitRequiresTimestamp(t *testing.T) {
 	assert.NoError(t, err)
 	_, err = verify.NewSignedEntityVerifier(tr, verify.WithTransparencyLog(1), verify.WithObserverTimestamps(1))
 	assert.NoError(t, err)
-	_, err = verify.NewSignedEntityVerifier(tr, verify.WithTransparencyLog(1), verify.WithoutAnyObserverTimestampsUnsafe())
+	_, err = verify.NewSignedEntityVerifier(tr, verify.WithTransparencyLog(1), verify.WithCurrentTime())
 	assert.NoError(t, err)
 }
 


### PR DESCRIPTION
Using a certificate's NBF will always pass the time verification. We should be using only the current time to try to verify a certificate's validity. This is likely to only work with long-lived certificates or where verification happens immediately after signing.

Updated conformance testing to drop detached testing. 

Fixes #276

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
