### PR TITLE
Add hard limits for number of TSA entries, Tlog entries, and attestation subjects/digests

### DIFF
--- a/pkg/verify/signature_test.go
+++ b/pkg/verify/signature_test.go
@@ -18,9 +18,12 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"testing"
 
+	"github.com/in-toto/in-toto-golang/in_toto"
+	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
 	"github.com/sigstore/sigstore-go/pkg/testing/ca"
 	"github.com/sigstore/sigstore-go/pkg/verify"
 	"github.com/stretchr/testify/assert"
@@ -112,4 +115,62 @@ func TestSignatureVerifierMessageSignature(t *testing.T) {
 	result, err = verifier.Verify(entity, verify.NewPolicy(verify.WithArtifact(bytes.NewBufferString(artifact2)), verify.WithoutIdentitiesUnsafe()))
 	assert.Error(t, err)
 	assert.Nil(t, result)
+}
+
+func TestTooManySubjects(t *testing.T) {
+	virtualSigstore, err := ca.NewVirtualSigstore()
+	assert.NoError(t, err)
+
+	tooManySubjectsStatement := in_toto.Statement{}
+	for i := 0; i < 1025; i++ {
+		tooManySubjectsStatement.Subject = append(tooManySubjectsStatement.Subject, in_toto.Subject{
+			Name: fmt.Sprintf("subject-%d", i),
+			Digest: map[string]string{
+				"sha256": "", // actual content of digest does not matter for this test
+			},
+		})
+	}
+
+	tooManySubjectsStatementBytes, err := json.Marshal(tooManySubjectsStatement)
+	assert.NoError(t, err)
+
+	tooManySubjectsEntity, err := virtualSigstore.Attest("foo@example.com", "issuer", tooManySubjectsStatementBytes)
+	assert.NoError(t, err)
+
+	verifier, err := verify.NewSignedEntityVerifier(virtualSigstore, verify.WithTransparencyLog(1), verify.WithObserverTimestamps(1))
+	assert.NoError(t, err)
+
+	artifact := "Hi, I am an artifact!"
+	_, err = verifier.Verify(tooManySubjectsEntity, verify.NewPolicy(verify.WithArtifact(bytes.NewBufferString(artifact)), verify.WithoutIdentitiesUnsafe()))
+	assert.ErrorContains(t, err, "too many subjects")
+}
+
+func TestTooManyDigests(t *testing.T) {
+	virtualSigstore, err := ca.NewVirtualSigstore()
+	assert.NoError(t, err)
+
+	tooManyDigestsStatement := in_toto.Statement{}
+	tooManyDigestsStatement.Subject = []in_toto.Subject{
+		{
+			Name:   fmt.Sprintf("subject"),
+			Digest: make(common.DigestSet),
+		},
+	}
+	tooManyDigestsStatement.Subject[0].Digest["sha512"] = "" // verifier requires that at least one known hash algorithm is present in the digest map
+	for i := 0; i < 32; i++ {
+		tooManyDigestsStatement.Subject[0].Digest[fmt.Sprintf("digest-%d", i)] = ""
+	}
+
+	tooManySubjectsStatementBytes, err := json.Marshal(tooManyDigestsStatement)
+	assert.NoError(t, err)
+
+	tooManySubjectsEntity, err := virtualSigstore.Attest("foo@example.com", "issuer", tooManySubjectsStatementBytes)
+	assert.NoError(t, err)
+
+	verifier, err := verify.NewSignedEntityVerifier(virtualSigstore, verify.WithTransparencyLog(1), verify.WithObserverTimestamps(1))
+	assert.NoError(t, err)
+
+	artifact := "Hi, I am an artifact!"
+	_, err = verifier.Verify(tooManySubjectsEntity, verify.NewPolicy(verify.WithArtifact(bytes.NewBufferString(artifact)), verify.WithoutIdentitiesUnsafe()))
+	assert.ErrorContains(t, err, "too many digests")
 }

--- a/pkg/verify/signature_test.go
+++ b/pkg/verify/signature_test.go
@@ -97,7 +97,7 @@ func TestSignatureVerifierMessageSignature(t *testing.T) {
 	virtualSigstore, err := ca.NewVirtualSigstore()
 	assert.NoError(t, err)
 
-	artifact := "Hi, I am an artifact!"
+	artifact := "Hi, I am an artifact!" //nolint:goconst
 	entity, err := virtualSigstore.Sign("foo@example.com", "issuer", []byte(artifact))
 	assert.NoError(t, err)
 
@@ -140,7 +140,7 @@ func TestTooManySubjects(t *testing.T) {
 	verifier, err := verify.NewSignedEntityVerifier(virtualSigstore, verify.WithTransparencyLog(1), verify.WithObserverTimestamps(1))
 	assert.NoError(t, err)
 
-	artifact := "Hi, I am an artifact!"
+	artifact := "Hi, I am an artifact!" //nolint:goconst
 	_, err = verifier.Verify(tooManySubjectsEntity, verify.NewPolicy(verify.WithArtifact(bytes.NewBufferString(artifact)), verify.WithoutIdentitiesUnsafe()))
 	assert.ErrorContains(t, err, "too many subjects")
 }
@@ -170,7 +170,7 @@ func TestTooManyDigests(t *testing.T) {
 	verifier, err := verify.NewSignedEntityVerifier(virtualSigstore, verify.WithTransparencyLog(1), verify.WithObserverTimestamps(1))
 	assert.NoError(t, err)
 
-	artifact := "Hi, I am an artifact!"
+	artifact := "Hi, I am an artifact!" //nolint:goconst
 	_, err = verifier.Verify(tooManySubjectsEntity, verify.NewPolicy(verify.WithArtifact(bytes.NewBufferString(artifact)), verify.WithoutIdentitiesUnsafe()))
 	assert.ErrorContains(t, err, "too many digests")
 }

--- a/pkg/verify/tlog.go
+++ b/pkg/verify/tlog.go
@@ -34,6 +34,8 @@ import (
 	"github.com/sigstore/sigstore-go/pkg/util"
 )
 
+const maxAllowedTlogEntries = 32
+
 // VerifyArtifactTransparencyLog verifies that the given entity has been logged
 // in the transparency log and that the log entry is valid.
 //
@@ -45,6 +47,11 @@ func VerifyArtifactTransparencyLog(entity SignedEntity, trustedMaterial root.Tru
 	entries, err := entity.TlogEntries()
 	if err != nil {
 		return nil, err
+	}
+
+	// limit the number of tlog entries to prevent DoS
+	if len(entries) > maxAllowedTlogEntries {
+		return nil, fmt.Errorf("too many tlog entries: %d > %d", len(entries), maxAllowedTlogEntries)
 	}
 
 	// disallow duplicate entries, as a malicious actor could use duplicates to bypass the threshold

--- a/pkg/verify/tsa.go
+++ b/pkg/verify/tsa.go
@@ -26,12 +26,19 @@ import (
 	"github.com/sigstore/sigstore-go/pkg/root"
 )
 
+const maxAllowedTimestamps = 32
+
 // VerifyTimestampAuthority verifies that the given entity has been timestamped
 // by a trusted timestamp authority and that the timestamp is valid.
 func VerifyTimestampAuthority(entity SignedEntity, trustedMaterial root.TrustedMaterial) ([]time.Time, error) { //nolint:revive
 	signedTimestamps, err := entity.Timestamps()
 	if err != nil {
 		return nil, err
+	}
+
+	// limit the number of timestamps to prevent DoS
+	if len(signedTimestamps) > maxAllowedTimestamps {
+		return nil, fmt.Errorf("too many signed timestamps: %d > %d", len(signedTimestamps), maxAllowedTimestamps)
 	}
 
 	// disallow duplicate timestamps, as a malicious actor could use duplicates to bypass the threshold


### PR DESCRIPTION
This reduces the capability of an adversary to craft a malicious bundle containing large numbers of these data, which can result in a target verifier process consuming high CPU and memory resources, resulting in an "endless data attack", a type of DoS attack.

Fixes https://github.com/sigstore/sigstore-go/security/advisories/GHSA-cq38-jh5f-37mq

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
