### PR TITLE
Use sentinel errors bundle validation in `validateBundle` func

### DIFF
--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -35,7 +35,9 @@ import (
 
 var ErrValidation = errors.New("validation error")
 var ErrUnsupportedMediaType = fmt.Errorf("%w: unsupported media type", ErrValidation)
+var ErrEmptyBundle = fmt.Errorf("%w: empty protobuf bundle", ErrValidation)
 var ErrMissingVerificationMaterial = fmt.Errorf("%w: missing verification material", ErrValidation)
+var ErrMissingBundleContent = fmt.Errorf("%w: missing bundle content", ErrValidation)
 var ErrUnimplemented = errors.New("unimplemented")
 var ErrInvalidAttestation = fmt.Errorf("%w: invalid attestation", ErrValidation)
 var ErrMissingEnvelope = fmt.Errorf("%w: missing valid envelope", ErrInvalidAttestation)
@@ -172,11 +174,11 @@ func getBundleVersion(mediaType string) (string, error) {
 
 func validateBundle(b *protobundle.Bundle) error {
 	if b == nil {
-		return fmt.Errorf("empty protobuf bundle")
+		return ErrEmptyBundle
 	}
 
 	if b.Content == nil {
-		return fmt.Errorf("missing bundle content")
+		return ErrMissingBundleContent
 	}
 
 	switch b.Content.(type) {

--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -185,12 +185,8 @@ func validateBundle(b *protobundle.Bundle) error {
 		return fmt.Errorf("invalid bundle content: bundle content must be either a message signature or dsse envelope")
 	}
 
-	if b.VerificationMaterial == nil {
-		return fmt.Errorf("missing verification material")
-	}
-
-	if b.VerificationMaterial.Content == nil {
-		return fmt.Errorf("missing verification material content")
+	if b.VerificationMaterial == nil || b.VerificationMaterial.Content == nil {
+		return ErrMissingVerificationMaterial
 	}
 
 	switch b.VerificationMaterial.Content.(type) {

--- a/pkg/bundle/bundle_test.go
+++ b/pkg/bundle/bundle_test.go
@@ -1067,7 +1067,7 @@ func Test_BundleValidation(t *testing.T) {
 					Content:   nil,
 				},
 			},
-			errMsg:  "invalid bundle: missing bundle content",
+			errMsg:  "invalid bundle: validation error: missing bundle content",
 			wantErr: true,
 		},
 		{

--- a/pkg/bundle/bundle_test.go
+++ b/pkg/bundle/bundle_test.go
@@ -1056,7 +1056,7 @@ func Test_BundleValidation(t *testing.T) {
 					Content: &protobundle.Bundle_MessageSignature{},
 				},
 			},
-			errMsg:  "invalid bundle: missing verification material content",
+			errMsg:  "invalid bundle: validation error: missing verification material",
 			wantErr: true,
 		},
 		{
@@ -1079,7 +1079,7 @@ func Test_BundleValidation(t *testing.T) {
 					VerificationMaterial: nil,
 				},
 			},
-			errMsg:  "invalid bundle: missing verification material",
+			errMsg:  "invalid bundle: validation error: missing verification material",
 			wantErr: true,
 		},
 		{


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This updates `validateBundle` so that it returns sentinel errors for verification issues. It uses a pre existing sentinel error and adds two new ones.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
