### PR TITLE
Add workflow to synchronize go mod changes with submodules

### DIFF
--- a/.github/chainguard/sync.sts.yaml
+++ b/.github/chainguard/sync.sts.yaml
@@ -1,0 +1,7 @@
+issuer: https://token.actions.githubusercontent.com
+subject: repo:sigstore/sigstore-go:pull_request
+claim_pattern:
+  actor: "dependabot\[bot\]"
+
+permissions:
+  contents: write

--- a/.github/workflows/synchronize-go-mod.yml
+++ b/.github/workflows/synchronize-go-mod.yml
@@ -1,0 +1,48 @@
+name: Synchronize go.mod in submodules
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+
+permissions:
+  contents: write
+
+jobs:
+  synchronize-go-mod:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Install Go
+        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          go-version-file: go.mod
+
+      - name: Synchronize go.mod in submodules
+        run: |
+          go mod tidy
+          cd examples/oci-image-verification; go mod tidy
+
+      - name: Commit and push changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "Changes detected:"
+            git diff
+            git config --global user.name "github-actions[bot]"
+            git config --global user.email "github-actions[bot]@users.noreply.github.com"
+            git commit -a -s -m "Synchronize go.mod in submodules"
+            git push origin HEAD:${{ github.event.pull_request.head.ref }}
+          else
+            echo "No changes to commit"
+          fi

--- a/.github/workflows/synchronize-go-mod.yml
+++ b/.github/workflows/synchronize-go-mod.yml
@@ -17,24 +17,28 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # v1.0.0
+        id: octo-sts
+        with:
+          scope: sigstore/sigstore-go
+          identity: sync
+
       - name: Checkout repository
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ steps.octo-sts.outputs.token }}
 
       - name: Install Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
           go-version-file: go.mod
 
-      - name: Synchronize go.mod in submodules
+      - name: Synchronize go.mod in submodule
         run: |
-          go mod tidy
           cd examples/oci-image-verification; go mod tidy
 
       - name: Commit and push changes
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ -n "$(git status --porcelain)" ]; then
             echo "Changes detected:"


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

This PR attempt to improve the workflow of managing Dependabot updates to this repo. The problem is that when Dependabot updates a dependency in the main module, those updates are not reflected in the "submodule" (https://github.com/sigstore/sigstore-go/tree/main/examples/oci-image-verification) which includes a reference to the main module. That causes the build to fail, and one maintainer must manually run `go mod tidy` in the submodule and push those changes, and another maintainer must approve and merge them (as the last committer is disallowed from merging a PR). ([example](https://github.com/sigstore/sigstore-go/pull/311))

This PR automatically runs `go mod tidy` in both modules and commits/pushes them whenever Dependabot creates a new PR.

There is a caveat with this, which is that the actions do not run when the last committer used `GITHUB_TOKEN` to authenticate to the Git server, which is [intentional to avoid accidentally creating recursively invoked workflows](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow). This can be worked around by using a PAT in this workflow to authenticate to the Git server, or maintainers can push an empty commit to trigger the Actions workflows.

If this seems like a good approach to fellow maintainers, I'd recommend we create a PAT for use within this repo and modify this workflow to use it.

This workflow could also be added to `sigstore/sigstore` for use with the KMS providers ([example](https://github.com/sigstore/sigstore/pull/1852)).

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
