### PR TITLE
Update oci-image-verification.md

### DIFF
--- a/docs/oci-image-verification.md
+++ b/docs/oci-image-verification.md
@@ -18,7 +18,7 @@ reference metadata as a prerequisite to the verification process.
 ## Requirements
 
 - Unix-compatible OS
-- [Go 1.21](https://go.dev/doc/install)
+- [Go 1.22](https://go.dev/doc/install)
 
 ## Getting started
 


### PR DESCRIPTION
#### Summary
sync the go version with the go.mod for oci-image-verification.md, follow-up on https://github.com/sigstore/sigstore-go/pull/319

#### Release Note
NONE

#### Documentation
n/a
