### PR TITLE
Improve TSA verification error handling

### DIFF
--- a/pkg/verify/signed_entity.go
+++ b/pkg/verify/signed_entity.go
@@ -815,15 +815,12 @@ func (v *SignedEntityVerifier) VerifyObserverTimestamps(entity SignedEntity, log
 
 	if v.config.requireObserverTimestamps {
 		verifiedSignedTimestamps, err := VerifyTimestampAuthority(entity, v.trustedMaterial)
-		if err != nil {
-			return nil, err
-		}
 
 		// check threshold for both RFC3161 and log timestamps
 		tsCount := len(verifiedSignedTimestamps) + len(logTimestamps)
 		if tsCount < v.config.observerTimestampThreshold {
-			return nil, fmt.Errorf("threshold not met for verified signed & log entry integrated timestamps: %d < %d",
-				tsCount, v.config.observerTimestampThreshold)
+			return nil, fmt.Errorf("threshold not met for verified signed & log entry integrated timestamps: %d < %d; error: %w",
+				tsCount, v.config.observerTimestampThreshold, err)
 		}
 
 		// append all timestamps

--- a/pkg/verify/tsa.go
+++ b/pkg/verify/tsa.go
@@ -67,7 +67,7 @@ func VerifyTimestampAuthority(entity SignedEntity, trustedMaterial root.TrustedM
 		verifiedTimestamps = append(verifiedTimestamps, verifiedSignedTimestamp)
 	}
 
-	if len(verifiedTimestamps) == 0 {
+	if len(verifiedTimestamps) == 0 && len(errs) > 0 {
 		return nil, fmt.Errorf("no verified signed timestamps: %w", errors.Join(errs...))
 	}
 	return verifiedTimestamps, nil

--- a/pkg/verify/tsa_test.go
+++ b/pkg/verify/tsa_test.go
@@ -15,6 +15,7 @@
 package verify_test
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -67,10 +68,11 @@ func TestTimestampAuthorityVerifierWithoutThreshold(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, ts, 1)
 
-	// no failure, but also no verified timestamps
+	// wrong instance; expect no verified timestamps
 	ts, err = verify.VerifyTimestampAuthority(entity, virtualSigstore2)
-	assert.NoError(t, err)
+	assert.Error(t, err)
 	assert.Empty(t, ts)
+	assert.ErrorContains(t, errors.Unwrap(err), "ECDSA verification failure")
 }
 
 type oneTrustedOneUntrustedTimestampEntity struct {


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

This PR adds more detail to the error output of `VerifyTimestampAuthority` by returning all verification errors. 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
