### PR TITLE
Fix intoto statement marshal/unmarshal

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/go-openapi/swag v0.23.0
 	github.com/google/certificate-transparency-go v1.2.1
 	github.com/in-toto/attestation v1.1.0
-	github.com/in-toto/in-toto-golang v0.9.0
 	github.com/secure-systems-lab/go-securesystemslib v0.8.0
 	github.com/sigstore/protobuf-specs v0.3.2
 	github.com/sigstore/rekor v1.3.6
@@ -51,6 +50,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/in-toto/in-toto-golang v0.9.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jedisct1/go-minisign v0.0.0-20211028175153-1c139d1cc84b // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/pkg/bundle/signature_content.go
+++ b/pkg/bundle/signature_content.go
@@ -17,7 +17,6 @@ package bundle
 import (
 	"encoding/base64"
 
-	in_toto "github.com/in-toto/attestation/go/v1"
 	"github.com/secure-systems-lab/go-securesystemslib/dsse"
 	"github.com/sigstore/sigstore-go/pkg/verify"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -51,12 +50,12 @@ type Envelope struct {
 	*dsse.Envelope
 }
 
-func (e *Envelope) Statement() (*in_toto.Statement, error) {
+func (e *Envelope) Statement() (*verify.Statement, error) {
 	if e.PayloadType != IntotoMediaType {
 		return nil, ErrUnsupportedMediaType
 	}
 
-	var statement in_toto.Statement
+	var statement verify.Statement
 	raw, err := e.DecodeB64Payload()
 	if err != nil {
 		return nil, ErrDecodingB64

--- a/pkg/verify/interface.go
+++ b/pkg/verify/interface.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"time"
 
-	in_toto "github.com/in-toto/attestation/go/v1"
 	"github.com/secure-systems-lab/go-securesystemslib/dsse"
 	protocommon "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
 	"github.com/sigstore/sigstore-go/pkg/root"
@@ -86,7 +85,7 @@ type MessageSignatureContent interface {
 
 type EnvelopeContent interface {
 	RawEnvelope() *dsse.Envelope
-	Statement() (*in_toto.Statement, error)
+	Statement() (*Statement, error)
 }
 
 // BaseSignedEntity is a helper struct that implements all the interfaces

--- a/pkg/verify/signed_entity.go
+++ b/pkg/verify/signed_entity.go
@@ -17,7 +17,6 @@ package verify
 import (
 	"crypto/x509"
 	"encoding/asn1"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -218,7 +217,7 @@ func (c *VerifierConfig) Validate() error {
 
 type VerificationResult struct {
 	MediaType          string                        `json:"mediaType"`
-	Statement          *in_toto.Statement            `json:"statement,omitempty"`
+	Statement          *Statement                    `json:"statement,omitempty"`
 	Signature          *SignatureVerificationResult  `json:"signature,omitempty"`
 	VerifiedTimestamps []TimestampVerificationResult `json:"verifiedTimestamps"`
 	VerifiedIdentity   *CertificateIdentity          `json:"verifiedIdentity,omitempty"`
@@ -241,43 +240,16 @@ func NewVerificationResult() *VerificationResult {
 	}
 }
 
-// verificationResultRawStatement is a helper struct to marshal/unmarshal
-// It is used because in_toto.Statement is a protobuf message and we want to
-// store it as a raw message so we can use protojson to marshal/unmarshal it
-//
-// See https://github.com/in-toto/attestation/issues/363
-type verificationResultRawStatement struct {
-	MediaType          string                        `json:"mediaType"`
-	Statement          json.RawMessage               `json:"statement,omitempty"`
-	Signature          *SignatureVerificationResult  `json:"signature,omitempty"`
-	VerifiedTimestamps []TimestampVerificationResult `json:"verifiedTimestamps"`
-	VerifiedIdentity   *CertificateIdentity          `json:"verifiedIdentity,omitempty"`
+type Statement struct {
+	in_toto.Statement
 }
 
-func (b *VerificationResult) MarshalJSON() ([]byte, error) {
-	statement, err := protojson.Marshal(b.Statement)
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(&verificationResultRawStatement{
-		MediaType:          b.MediaType,
-		Statement:          statement,
-		Signature:          b.Signature,
-		VerifiedTimestamps: b.VerifiedTimestamps,
-		VerifiedIdentity:   b.VerifiedIdentity,
-	})
+func (s *Statement) MarshalJSON() ([]byte, error) {
+	return protojson.Marshal(&s.Statement)
 }
 
-func (b *VerificationResult) UnmarshalJSON(data []byte) error {
-	var aux verificationResultRawStatement
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	b.MediaType = aux.MediaType
-	b.Signature = aux.Signature
-	b.VerifiedTimestamps = aux.VerifiedTimestamps
-	b.VerifiedIdentity = aux.VerifiedIdentity
-	return protojson.Unmarshal(aux.Statement, b.Statement)
+func (s *Statement) UnmarshalJSON(data []byte) error {
+	return protojson.Unmarshal(data, s)
 }
 
 type PolicyOption func(*PolicyConfig) error

--- a/pkg/verify/signed_entity.go
+++ b/pkg/verify/signed_entity.go
@@ -17,6 +17,7 @@ package verify
 import (
 	"crypto/x509"
 	"encoding/asn1"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -26,6 +27,7 @@ import (
 	"github.com/sigstore/sigstore-go/pkg/fulcio/certificate"
 	"github.com/sigstore/sigstore-go/pkg/root"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 const (
@@ -237,6 +239,45 @@ func NewVerificationResult() *VerificationResult {
 	return &VerificationResult{
 		MediaType: VerificationResultMediaType01,
 	}
+}
+
+// verificationResultRawStatement is a helper struct to marshal/unmarshal
+// It is used because in_toto.Statement is a protobuf message and we want to
+// store it as a raw message so we can use protojson to marshal/unmarshal it
+//
+// See https://github.com/in-toto/attestation/issues/363
+type verificationResultRawStatement struct {
+	MediaType          string                        `json:"mediaType"`
+	Statement          json.RawMessage               `json:"statement,omitempty"`
+	Signature          *SignatureVerificationResult  `json:"signature,omitempty"`
+	VerifiedTimestamps []TimestampVerificationResult `json:"verifiedTimestamps"`
+	VerifiedIdentity   *CertificateIdentity          `json:"verifiedIdentity,omitempty"`
+}
+
+func (b *VerificationResult) MarshalJSON() ([]byte, error) {
+	statement, err := protojson.Marshal(b.Statement)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(&verificationResultRawStatement{
+		MediaType:          b.MediaType,
+		Statement:          statement,
+		Signature:          b.Signature,
+		VerifiedTimestamps: b.VerifiedTimestamps,
+		VerifiedIdentity:   b.VerifiedIdentity,
+	})
+}
+
+func (b *VerificationResult) UnmarshalJSON(data []byte) error {
+	var aux verificationResultRawStatement
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	b.MediaType = aux.MediaType
+	b.Signature = aux.Signature
+	b.VerifiedTimestamps = aux.VerifiedTimestamps
+	b.VerifiedIdentity = aux.VerifiedIdentity
+	return protojson.Unmarshal(aux.Statement, b.Statement)
 }
 
 type PolicyOption func(*PolicyConfig) error

--- a/pkg/verify/signed_entity_test.go
+++ b/pkg/verify/signed_entity_test.go
@@ -23,9 +23,11 @@ import (
 	"encoding/hex"
 	"encoding/json"
 
+	in_toto "github.com/in-toto/attestation/go/v1"
 	"github.com/sigstore/sigstore-go/pkg/testing/data"
 	"github.com/sigstore/sigstore-go/pkg/verify"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func TestSignedEntityVerifierInitialization(t *testing.T) {
@@ -421,4 +423,41 @@ func TestSigstoreBundle2Sig(t *testing.T) {
 	res, err := v.Verify(entity, SkipArtifactAndIdentitiesPolicy)
 	assert.True(t, errors.Is(err, verify.ErrDSSEInvalidSignatureCount))
 	assert.Nil(t, res)
+}
+
+func TestStatementSerializesToValidInTotoStatement(t *testing.T) {
+	// create instance of verify.Statement with dummy values
+	statement := verify.Statement{}
+	statement.Type = "https://in-toto.io/Statement/v0.1"
+	statement.PredicateType = "https://example.org/predicate"
+	statement.Subject = []*in_toto.ResourceDescriptor{
+		{
+			Name: "artifact-name",
+			Digest: map[string]string{
+				"sha256": "artifact-digest",
+			},
+		},
+	}
+	statement.Predicate = &structpb.Struct{
+		Fields: map[string]*structpb.Value{},
+	}
+
+	// marshal the statement to JSON
+	statementJSON, err := json.Marshal(&statement)
+	assert.NoError(t, err)
+	want := `
+	{
+		"_type": "https://in-toto.io/Statement/v0.1",
+		"predicateType": "https://example.org/predicate",
+		"subject": [
+			{
+				"name": "artifact-name",
+				"digest": {
+					"sha256": "artifact-digest"
+				}
+			}
+		],
+		"predicate": {}
+	}`
+	assert.JSONEq(t, want, string(statementJSON))
 }


### PR DESCRIPTION
This pull request addresses a bug in the JSON marshaling of the in-toto statement in verification results. It currently outputs "predicate_type" instead of "predicateType" [required by the spec](https://github.com/in-toto/attestation/blob/main/spec/v1/predicate.md). 

The issue is related to in-toto/attestation#363, this applies the fix mentioned there, defining custom marshaler/unmarshaler on the VerificationResult struct and selectively marshaling/unmarshaling the statement using google.golang.org/protobuf/encoding/protojson