### PR TITLE
Update BaseSignedEntity interface implementation

### DIFF
--- a/pkg/verify/interface.go
+++ b/pkg/verify/interface.go
@@ -21,7 +21,6 @@ import (
 
 	in_toto "github.com/in-toto/attestation/go/v1"
 	"github.com/secure-systems-lab/go-securesystemslib/dsse"
-	protocommon "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
 	"github.com/sigstore/sigstore-go/pkg/root"
 	"github.com/sigstore/sigstore-go/pkg/tlog"
 )
@@ -95,19 +94,21 @@ type EnvelopeContent interface {
 // that only implements a subset of the interfaces.
 type BaseSignedEntity struct{}
 
-func (b *BaseSignedEntity) VerificationProvider() (VerificationContent, error) {
+var _ SignedEntity = &BaseSignedEntity{}
+
+func (b *BaseSignedEntity) HasInclusionPromise() bool {
+	return false
+}
+
+func (b *BaseSignedEntity) HasInclusionProof() bool {
+	return false
+}
+
+func (b *BaseSignedEntity) VerificationContent() (VerificationContent, error) {
 	return nil, errNotImplemented
 }
 
-func (b *BaseSignedEntity) Envelope() (*dsse.Envelope, error) {
-	return nil, errNotImplemented
-}
-
-func (b *BaseSignedEntity) MessageSignature() (*protocommon.MessageSignature, error) {
-	return nil, errNotImplemented
-}
-
-func (b *BaseSignedEntity) Signature() ([]byte, error) {
+func (b *BaseSignedEntity) SignatureContent() (SignatureContent, error) {
 	return nil, errNotImplemented
 }
 


### PR DESCRIPTION
The SignedEntity interface has gone through a few iterations. The BaseSignedEntity struct was not keeping up with it, which wasn't caught because it is never used in sigstore-go. This change updates the struct to implement the interface it was meant to implement, and adds an assignment statement to make sure future errors in updates are caught at compile time.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
