### PR TITLE
ci: address zizmor's findings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
       - name: Install Go
         uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,14 +23,15 @@ on:
   schedule:
     - cron: '45 10 * * 1'
 
-permissions:
-  contents: read
-  security-events: write
+permissions: {}
 
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
 
     strategy:
       fail-fast: false
@@ -39,6 +40,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        persist-credentials: false
 
     - name: Setup Go
       uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -31,6 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version-file: go.mod

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -26,6 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version-file: './go.mod'

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -25,8 +25,8 @@ on:
   push:
     branches: [ main ]
 
-# Declare default permissions as read only.
-permissions: read-all
+# Disable all default permissions.
+permissions: {}
 
 jobs:
   analysis:

--- a/.github/workflows/verify_license.yml
+++ b/.github/workflows/verify_license.yml
@@ -25,6 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version-file: './go.mod'


### PR DESCRIPTION
This addresses a bunch of low-impact findings from [`zizmor`](https://github.com/woodruffw/zizmor), all of which are disabling unneeded credential persistence or moving `permissions:` stanzas into their dependent jobs.

NB: This changeset doesn't include a new workflow for `zizmor`, but if folks are interested [this one](https://woodruffw.github.io/zizmor/usage/#use-in-github-actions) should be drag-n-drop 🙂 

Afterwards:

```
$ zizmor .
🌈 completed codeql.yml
🌈 completed golangci-lint.yml
🌈 completed verify_license.yml
🌈 completed depsreview.yml
🌈 completed build.yml
🌈 completed scorecard.yml
🌈 completed conformance.yml
No findings to report. Good job!
```