### PR TITLE
Remove online Rekor lookups for verification

### DIFF
--- a/cmd/conformance/main.go
+++ b/cmd/conformance/main.go
@@ -300,9 +300,6 @@ func main() {
 
 		verifierConfig := []verify.VerifierOption{}
 		verifierConfig = append(verifierConfig, verify.WithoutAnyObserverTimestampsUnsafe(), verify.WithSignedCertificateTimestamps(1))
-		if len(tr.RekorLogs()) > 0 {
-			verifierConfig = append(verifierConfig, verify.WithOnlineVerification())
-		}
 
 		// Verify bundle
 		sev, err := verify.NewSignedEntityVerifier(tr, verifierConfig...)

--- a/cmd/sigstore-go/main.go
+++ b/cmd/sigstore-go/main.go
@@ -48,7 +48,6 @@ var requireTimestamp *bool
 var requireCTlog *bool
 var requireTlog *bool
 var minBundleVersion *string
-var onlineTlog *bool
 var trustedPublicKey *string
 var trustedrootJSONpath *string
 var tufRootURL *string
@@ -66,7 +65,6 @@ func init() {
 	requireCTlog = flag.Bool("requireCTlog", true, "Require Certificate Transparency log entry")
 	requireTlog = flag.Bool("requireTlog", true, "Require Artifact Transparency log entry (Rekor)")
 	minBundleVersion = flag.String("minBundleVersion", "", "Minimum acceptable bundle version (e.g. '0.1')")
-	onlineTlog = flag.Bool("onlineTlog", false, "Verify Artifact Transparency log entry online (Rekor)")
 	trustedPublicKey = flag.String("publicKey", "", "Path to trusted public key")
 	trustedrootJSONpath = flag.String("trustedrootJSONpath", "examples/trusted-root-public-good.json", "Path to trustedroot JSON file")
 	tufRootURL = flag.String("tufRootURL", "", "URL of TUF root containing trusted root JSON file")
@@ -116,10 +114,6 @@ func run() error {
 
 	if *requireTlog {
 		verifierConfig = append(verifierConfig, verify.WithTransparencyLog(1))
-	}
-
-	if *onlineTlog {
-		verifierConfig = append(verifierConfig, verify.WithOnlineVerification())
 	}
 
 	certID, err := verify.NewShortCertificateIdentity(*expectedOIDIssuer, *expectedOIDIssuerRegex, *expectedSAN, *expectedSANRegex)

--- a/examples/oci-image-verification/main.go
+++ b/examples/oci-image-verification/main.go
@@ -55,7 +55,6 @@ var ignoreSCT *bool
 var requireTimestamp *bool
 var requireTlog *bool
 var minBundleVersion *string
-var onlineTlog *bool
 var trustedPublicKey *string
 var trustedrootJSONpath *string
 var tufRootURL *string
@@ -74,7 +73,6 @@ func init() {
 	requireTimestamp = flag.Bool("requireTimestamp", true, "Require either an RFC3161 signed timestamp or log entry integrated timestamp")
 	requireTlog = flag.Bool("requireTlog", true, "Require Artifact Transparency log entry (Rekor)")
 	minBundleVersion = flag.String("minBundleVersion", "", "Minimum acceptable bundle version (e.g. '0.1')")
-	onlineTlog = flag.Bool("onlineTlog", false, "Verify Artifact Transparency log entry online (Rekor)")
 	trustedPublicKey = flag.String("publicKey", "", "Path to trusted public key")
 	trustedrootJSONpath = flag.String("trustedrootJSONpath", "examples/trusted-root-public-good.json", "Path to trustedroot JSON file")
 	tufRootURL = flag.String("tufRootURL", "", "URL of TUF root containing trusted root JSON file")
@@ -133,10 +131,6 @@ func run() error {
 
 	if *requireTlog {
 		verifierConfig = append(verifierConfig, verify.WithTransparencyLog(1))
-	}
-
-	if *onlineTlog {
-		verifierConfig = append(verifierConfig, verify.WithOnlineVerification())
 	}
 
 	if *expectedOIDIssuer != "" || *expectedOIDIssuerRegex != "" || *expectedSAN != "" || *expectedSANRegex != "" {

--- a/pkg/verify/fuzz_test.go
+++ b/pkg/verify/fuzz_test.go
@@ -99,8 +99,7 @@ func FuzzVerifyArtifactTransparencyLog(f *testing.F) {
 		verify.VerifyArtifactTransparencyLog(entity,
 			virtualSigstore,
 			logThreshold,
-			trustIntegratedTime,
-			false)
+			trustIntegratedTime)
 	})
 }
 

--- a/pkg/verify/signed_entity.go
+++ b/pkg/verify/signed_entity.go
@@ -38,9 +38,6 @@ type SignedEntityVerifier struct {
 }
 
 type VerifierConfig struct { // nolint: revive
-	// performOnlineVerification queries logs during verification.
-	// Default is offline
-	performOnlineVerification bool
 	// weExpectSignedTimestamps requires RFC3161 timestamps to verify
 	// short-lived certificates
 	weExpectSignedTimestamps bool
@@ -107,16 +104,6 @@ func NewSignedEntityVerifier(trustedMaterial root.TrustedMaterial, options ...Ve
 	}
 
 	return v, nil
-}
-
-// WithOnlineVerification configures the SignedEntityVerifier to perform
-// online verification when verifying Transparency Log entries and
-// Signed Certificate Timestamps.
-func WithOnlineVerification() VerifierOption {
-	return func(c *VerifierConfig) error {
-		c.performOnlineVerification = true
-		return nil
-	}
 }
 
 // WithSignedTimestamps configures the SignedEntityVerifier to expect RFC 3161
@@ -663,7 +650,7 @@ func (v *SignedEntityVerifier) VerifyTransparencyLogInclusion(entity SignedEntit
 	if v.config.weExpectTlogEntries {
 		// log timestamps should be verified if with WithIntegratedTimestamps or WithObserverTimestamps is used
 		verifiedTlogTimestamps, err := VerifyArtifactTransparencyLog(entity, v.trustedMaterial, v.config.tlogEntriesThreshold,
-			v.config.requireIntegratedTimestamps || v.config.requireObserverTimestamps, v.config.performOnlineVerification)
+			v.config.requireIntegratedTimestamps || v.config.requireObserverTimestamps)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/verify/tlog_test.go
+++ b/pkg/verify/tlog_test.go
@@ -16,16 +16,10 @@ package verify_test
 
 import (
 	"encoding/base64"
-	"errors"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/go-openapi/runtime"
-	"github.com/go-openapi/swag"
-	rekorGeneratedClient "github.com/sigstore/rekor/pkg/generated/client"
-	"github.com/sigstore/rekor/pkg/generated/client/entries"
-	"github.com/sigstore/rekor/pkg/generated/models"
 	"github.com/sigstore/sigstore-go/pkg/root"
 	"github.com/sigstore/sigstore-go/pkg/testing/ca"
 	"github.com/sigstore/sigstore-go/pkg/tlog"
@@ -43,12 +37,12 @@ func TestTlogVerifier(t *testing.T) {
 	assert.NoError(t, err)
 
 	var ts []root.Timestamp
-	ts, err = verify.VerifyArtifactTransparencyLog(entity, virtualSigstore, 1, true, false)
+	ts, err = verify.VerifyArtifactTransparencyLog(entity, virtualSigstore, 1, true)
 	assert.NoError(t, err)
 	// 1 verified timestamp
 	assert.Len(t, ts, 1)
 
-	ts, err = verify.VerifyArtifactTransparencyLog(entity, virtualSigstore, 1, false, false)
+	ts, err = verify.VerifyArtifactTransparencyLog(entity, virtualSigstore, 1, false)
 	assert.NoError(t, err)
 	// 0 verified timestamps, since integrated timestamps are ignored
 	assert.Len(t, ts, 0)
@@ -56,7 +50,7 @@ func TestTlogVerifier(t *testing.T) {
 	virtualSigstore2, err := ca.NewVirtualSigstore()
 	assert.NoError(t, err)
 
-	_, err = verify.VerifyArtifactTransparencyLog(entity, virtualSigstore2, 1, true, false)
+	_, err = verify.VerifyArtifactTransparencyLog(entity, virtualSigstore2, 1, true)
 	assert.Error(t, err) // different sigstore instance should fail to verify
 
 	// Attempt to use tlog with integrated time outside certificate validity.
@@ -66,7 +60,7 @@ func TestTlogVerifier(t *testing.T) {
 	entity, err = virtualSigstore.AttestAtTime("foo@example.com", "issuer", statement, time.Now().Add(30*time.Minute), false)
 	assert.NoError(t, err)
 
-	_, err = verify.VerifyArtifactTransparencyLog(entity, virtualSigstore, 1, true, false)
+	_, err = verify.VerifyArtifactTransparencyLog(entity, virtualSigstore, 1, true)
 	assert.Error(t, err)
 }
 
@@ -103,11 +97,11 @@ func TestIgnoredTLogEntries(t *testing.T) {
 	assert.NoError(t, err)
 
 	// success: entry that cannot be verified is ignored
-	_, err = verify.VerifyArtifactTransparencyLog(&oneTrustedOneUntrustedLogEntry{entity, untrustedEntity}, virtualSigstore, 1, true, false)
+	_, err = verify.VerifyArtifactTransparencyLog(&oneTrustedOneUntrustedLogEntry{entity, untrustedEntity}, virtualSigstore, 1, true)
 	assert.NoError(t, err)
 
 	// failure: threshold of 2 is not met since 1 untrusted entry is ignored
-	_, err = verify.VerifyArtifactTransparencyLog(&oneTrustedOneUntrustedLogEntry{entity, untrustedEntity}, virtualSigstore, 2, true, false)
+	_, err = verify.VerifyArtifactTransparencyLog(&oneTrustedOneUntrustedLogEntry{entity, untrustedEntity}, virtualSigstore, 2, true)
 	assert.Error(t, err)
 }
 
@@ -145,7 +139,7 @@ func TestInvalidTLogEntries(t *testing.T) {
 	assert.NoError(t, err)
 
 	// failure: threshold of 1 is not met with invalid entry
-	_, err = verify.VerifyArtifactTransparencyLog(&invalidTLogEntity{entity}, virtualSigstore, 1, true, false)
+	_, err = verify.VerifyArtifactTransparencyLog(&invalidTLogEntity{entity}, virtualSigstore, 1, true)
 	assert.Error(t, err)
 	if err.Error() != "entry must contain an inclusion proof and/or promise" {
 		t.Errorf("expected error with missing proof/promises, got: %v", err.Error())
@@ -169,7 +163,7 @@ func TestNoTLogEntries(t *testing.T) {
 	assert.NoError(t, err)
 
 	// failure: threshold of 1 is not met with no entries
-	_, err = verify.VerifyArtifactTransparencyLog(&noTLogEntity{entity}, virtualSigstore, 1, true, false)
+	_, err = verify.VerifyArtifactTransparencyLog(&noTLogEntity{entity}, virtualSigstore, 1, true)
 	assert.Error(t, err)
 	if !strings.Contains(err.Error(), "not enough verified log entries from transparency log") {
 		t.Errorf("expected error with timestamp threshold, got: %v", err.Error())
@@ -197,7 +191,7 @@ func TestDuplicateTlogEntries(t *testing.T) {
 	entity, err := virtualSigstore.Attest("foo@example.com", "issuer", statement)
 	assert.NoError(t, err)
 
-	_, err = verify.VerifyArtifactTransparencyLog(&dupTlogEntity{entity}, virtualSigstore, 1, true, false)
+	_, err = verify.VerifyArtifactTransparencyLog(&dupTlogEntity{entity}, virtualSigstore, 1, true)
 	assert.ErrorContains(t, err, "duplicate tlog entries found") // duplicate tlog entries should fail to verify
 }
 
@@ -225,160 +219,8 @@ func TestMaxAllowedTlogEntries(t *testing.T) {
 	entity, err := virtualSigstore.Attest("foo@example.com", "issuer", statement)
 	assert.NoError(t, err)
 
-	_, err = verify.VerifyArtifactTransparencyLog(&tooManyTlogEntriesEntity{entity}, virtualSigstore, 1, true, false)
+	_, err = verify.VerifyArtifactTransparencyLog(&tooManyTlogEntriesEntity{entity}, virtualSigstore, 1, true)
 	assert.ErrorContains(t, err, "too many tlog entries") // too many tlog entries should fail to verify
-}
-
-type mockEntriesClient struct {
-	Entries []*models.LogEntry
-}
-
-func newMockRekorEntriesClient(virtualSigstore ca.VirtualSigstore, statement []byte, integratedTime time.Time) (*mockEntriesClient, error) {
-	var err error
-	base64Statement := base64.StdEncoding.EncodeToString(statement)
-	verification := &models.LogEntryAnonVerification{}
-	verification.InclusionProof, err = virtualSigstore.GetInclusionProof(statement)
-	if err != nil {
-		return nil, err
-	}
-	logID, err := virtualSigstore.RekorLogID()
-	if err != nil {
-		return nil, err
-	}
-	bundle := &tlog.RekorPayload{
-		LogID:          logID,
-		IntegratedTime: integratedTime.Unix(),
-		LogIndex:       0,
-		Body:           base64Statement,
-	}
-	verification.SignedEntryTimestamp, err = virtualSigstore.RekorSignPayload(*bundle)
-	if err != nil {
-		return nil, err
-	}
-
-	var logEntry models.LogEntry = make(models.LogEntry)
-	logEntry["foo"] = models.LogEntryAnon{
-		Body:           base64Statement,
-		IntegratedTime: swag.Int64(integratedTime.Unix()),
-		LogIndex:       swag.Int64(0),
-		LogID:          swag.String(logID),
-		Verification:   verification,
-	}
-	mockRekor := &mockEntriesClient{
-		Entries: []*models.LogEntry{&logEntry},
-	}
-	return mockRekor, nil
-}
-
-func (m *mockEntriesClient) CreateLogEntry(_ *entries.CreateLogEntryParams, _ ...entries.ClientOption) (*entries.CreateLogEntryCreated, error) {
-	return nil, errors.New("not implemented")
-}
-
-func (m *mockEntriesClient) GetLogEntryByIndex(params *entries.GetLogEntryByIndexParams, _ ...entries.ClientOption) (*entries.GetLogEntryByIndexOK, error) {
-	resp := &entries.GetLogEntryByIndexOK{}
-	if len(m.Entries) != 0 {
-		for _, e := range m.Entries {
-			for _, i := range *e {
-				if *i.LogIndex == params.LogIndex {
-					resp.Payload = *e
-				}
-			}
-		}
-
-		if resp.Payload == nil {
-			resp.Payload = *m.Entries[0]
-		}
-	}
-	return resp, nil
-}
-
-func (m *mockEntriesClient) GetLogEntryByUUID(_ *entries.GetLogEntryByUUIDParams, _ ...entries.ClientOption) (*entries.GetLogEntryByUUIDOK, error) {
-	return nil, errors.New("not implemented")
-}
-
-func (m *mockEntriesClient) SearchLogQuery(_ *entries.SearchLogQueryParams, _ ...entries.ClientOption) (*entries.SearchLogQueryOK, error) {
-	return nil, errors.New("not implemented")
-}
-
-func (m *mockEntriesClient) SetTransport(_ runtime.ClientTransport) {}
-
-func TestOnlineVerification(t *testing.T) {
-	virtualSigstore, err := ca.NewVirtualSigstore()
-	assert.NoError(t, err)
-
-	statement := []byte(`{"_type":"https://in-toto.io/Statement/v0.1","predicateType":"customFoo","subject":[{"name":"subject","digest":{"sha256":"deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"}}],"predicate":{}}`)
-	integratedTime := time.Now().Add(5 * time.Minute)
-	entity, err := virtualSigstore.AttestAtTime("foo@example.com", "issuer", statement, integratedTime, true)
-	assert.NoError(t, err)
-
-	entriesClient, err := newMockRekorEntriesClient(*virtualSigstore, statement, integratedTime)
-	assert.NoError(t, err)
-	mockRekor := &rekorGeneratedClient.Rekor{
-		Entries: entriesClient,
-	}
-
-	oldRekorClientGetter := verify.RekorClientGetter
-	verify.RekorClientGetter = func(_ string) (*rekorGeneratedClient.Rekor, error) { return mockRekor, nil }
-	defer func() { verify.RekorClientGetter = oldRekorClientGetter }()
-
-	_, err = verify.VerifyArtifactTransparencyLog(entity, virtualSigstore, 1, true, true)
-	assert.NoError(t, err)
-}
-
-func TestNoInclusionProofOnline(t *testing.T) {
-	virtualSigstore, err := ca.NewVirtualSigstore()
-	assert.NoError(t, err)
-
-	statement := []byte(`{"_type":"https://in-toto.io/Statement/v0.1","predicateType":"customFoo","subject":[{"name":"subject","digest":{"sha256":"deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"}}],"predicate":{}}`)
-	integratedTime := time.Now().Add(5 * time.Minute)
-	entity, err := virtualSigstore.AttestAtTime("foo@example.com", "issuer", statement, integratedTime, false)
-	assert.NoError(t, err)
-
-	entriesClient, err := newMockRekorEntriesClient(*virtualSigstore, statement, integratedTime)
-	assert.NoError(t, err)
-	mockRekor := &rekorGeneratedClient.Rekor{
-		Entries: entriesClient,
-	}
-
-	oldRekorClientGetter := verify.RekorClientGetter
-	verify.RekorClientGetter = func(_ string) (*rekorGeneratedClient.Rekor, error) { return mockRekor, nil }
-	defer func() { verify.RekorClientGetter = oldRekorClientGetter }()
-
-	_, err = verify.VerifyArtifactTransparencyLog(entity, virtualSigstore, 1, true, true)
-	assert.NoError(t, err)
-}
-
-func TestNoInclusionProofAndRekorVerification(t *testing.T) {
-	virtualSigstore, err := ca.NewVirtualSigstore()
-	assert.NoError(t, err)
-
-	statement := []byte(`{"_type":"https://in-toto.io/Statement/v0.1","predicateType":"customFoo","subject":[{"name":"subject","digest":{"sha256":"deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"}}],"predicate":{}}`)
-	integratedTime := time.Now().Add(5 * time.Minute)
-	entity, err := virtualSigstore.AttestAtTime("foo@example.com", "issuer", statement, integratedTime, true)
-	assert.NoError(t, err)
-
-	logID, err := virtualSigstore.RekorLogID()
-	assert.NoError(t, err)
-
-	var logEntry models.LogEntry = make(models.LogEntry)
-	logEntry["foo"] = models.LogEntryAnon{
-		Body:           base64.StdEncoding.EncodeToString(statement),
-		IntegratedTime: swag.Int64(integratedTime.Unix()),
-		LogIndex:       swag.Int64(0),
-		LogID:          swag.String(logID),
-	}
-	mockRekor := &rekorGeneratedClient.Rekor{
-		Entries: &mockEntriesClient{
-			Entries: []*models.LogEntry{&logEntry},
-		},
-	}
-
-	oldRekorClientGetter := verify.RekorClientGetter
-	verify.RekorClientGetter = func(_ string) (*rekorGeneratedClient.Rekor, error) { return mockRekor, nil }
-	defer func() { verify.RekorClientGetter = oldRekorClientGetter }()
-
-	_, err = verify.VerifyArtifactTransparencyLog(entity, virtualSigstore, 1, true, true)
-	assert.ErrorContains(t, err, "inclusion proof not provided")
 }
 
 func TestOfflineInclusionProofVerification(t *testing.T) {
@@ -390,6 +232,6 @@ func TestOfflineInclusionProofVerification(t *testing.T) {
 	entity, err := virtualSigstore.AttestAtTime("foo@example.com", "issuer", statement, integratedTime, true)
 	assert.NoError(t, err)
 
-	_, err = verify.VerifyArtifactTransparencyLog(entity, virtualSigstore, 1, true, false)
+	_, err = verify.VerifyArtifactTransparencyLog(entity, virtualSigstore, 1, true)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION


<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
For #80

Eventually we're going to remove the lookup ability from Rekor, and there's no security difference between online and offline.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
* Removed `WithOnlineVerification()` configuration option, and `online` argument to `VerifyArtifactTransparencyLog()`

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
N/A