### PR TITLE
Use glob support for directories key

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,8 +17,7 @@ version: 2
 updates:
   - package-ecosystem: gomod
     directories:
-      - "/"
-      - "/examples/oci-image-verification"
+      - "**/*"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

The previous PR #380 didn't behave as expected (still created PR only against main module).

This version uses a single glob that I believe will capture both modules.

Looking at https://github.com/inspektor-gadget/inspektor-gadget/pulls?q=is%3Apr+dependabot+is%3Aclosed as an example of a repo that got this right.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
