### PR TITLE
Add missing binary to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/tuf/testing.local.json
 /examples/oci-image-verification/oci-image-verification
 /examples/sigstore-go-signing/sigstore-go-signing
+/examples/sigstore-go-verification/sigstore-go-verification


### PR DESCRIPTION
If you run `make` which builds the examples, there is a missing file that is attempted to be added to the commit; this adds the binary to `.gitignore` which will prevent it from being accidentally checked in.