### PR TITLE
Update `Keypair.SignData` with context param

### DIFF
--- a/pkg/sign/certificate.go
+++ b/pkg/sign/certificate.go
@@ -130,7 +130,7 @@ func (f *Fulcio) GetCertificate(ctx context.Context, keypair Keypair, opts *Cert
 	}
 
 	// Sign JWT subject for proof of possession
-	subjectSignature, _, err := keypair.SignData([]byte(subject))
+	subjectSignature, _, err := keypair.SignData(ctx, []byte(subject))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sign/keys.go
+++ b/pkg/sign/keys.go
@@ -15,6 +15,7 @@
 package sign
 
 import (
+	"context"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
@@ -34,7 +35,7 @@ type Keypair interface {
 	GetHint() []byte
 	GetKeyAlgorithm() string
 	GetPublicKeyPem() (string, error)
-	SignData(data []byte) ([]byte, []byte, error)
+	SignData(ctx context.Context, data []byte) ([]byte, []byte, error)
 }
 
 type EphemeralKeypairOptions struct {
@@ -112,7 +113,7 @@ func getHashFunc(hashAlgorithm protocommon.HashAlgorithm) (crypto.Hash, error) {
 	}
 }
 
-func (e *EphemeralKeypair) SignData(data []byte) ([]byte, []byte, error) {
+func (e *EphemeralKeypair) SignData(_ context.Context, data []byte) ([]byte, []byte, error) {
 	hashFunc, err := getHashFunc(e.hashAlgorithm)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/sign/keys_test.go
+++ b/pkg/sign/keys_test.go
@@ -15,6 +15,7 @@
 package sign
 
 import (
+	"context"
 	"testing"
 
 	protocommon "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
@@ -26,6 +27,7 @@ func Test_EphemeralKeypair(t *testing.T) {
 		Hint: []byte("asdf"),
 	}
 
+	ctx := context.TODO()
 	ephemeralKeypair, err := NewEphemeralKeypair(opts)
 	assert.NotNil(t, ephemeralKeypair)
 	assert.Nil(t, err)
@@ -43,7 +45,7 @@ func Test_EphemeralKeypair(t *testing.T) {
 	assert.NotEqual(t, pem, "")
 	assert.Nil(t, err)
 
-	signature, digest, err := ephemeralKeypair.SignData([]byte("hello world"))
+	signature, digest, err := ephemeralKeypair.SignData(ctx, []byte("hello world"))
 	assert.NotEqual(t, signature, "")
 	assert.NotEqual(t, digest, "")
 	assert.Nil(t, err)

--- a/pkg/sign/signer.go
+++ b/pkg/sign/signer.go
@@ -65,7 +65,7 @@ func Bundle(content Content, keypair Keypair, opts BundleOptions) (*protobundle.
 	verifierOptions := []verify.VerifierOption{}
 
 	// Sign content and add to bundle
-	signature, digest, err := keypair.SignData(content.PreAuthEncoding())
+	signature, digest, err := keypair.SignData(opts.Context, content.PreAuthEncoding())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sign/transparency_test.go
+++ b/pkg/sign/transparency_test.go
@@ -103,6 +103,8 @@ func (m *mockRekor) CreateLogEntry(_ *entries.CreateLogEntryParams, _ ...entries
 }
 
 func Test_GetTransparencyLogEntry(t *testing.T) {
+	ctx := context.TODO()
+
 	// First create a bundle with DSSE content
 	keypair, err := NewEphemeralKeypair(nil)
 	assert.Nil(t, err)
@@ -110,7 +112,7 @@ func Test_GetTransparencyLogEntry(t *testing.T) {
 	bundle := &protobundle.Bundle{MediaType: bundleV03MediaType}
 	content := DSSEData{Data: []byte("hello world"), PayloadType: "something"}
 	envelopeBody = content.PreAuthEncoding()
-	signature, digest, err := keypair.SignData(content.PreAuthEncoding())
+	signature, digest, err := keypair.SignData(ctx, content.PreAuthEncoding())
 	assert.Nil(t, err)
 
 	content.Bundle(bundle, signature, digest, keypair.GetHashAlgorithm())


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Updates the signature for the `SignData` function in the `Keypair` interface to include a `Context` parameter.

There's maybe a case to be made that ALL of the functions in the `Keypair` interface should include a `Context` parameter . . . however, in most cases there's probably a reasonable way to pre-calculate the values returned by those functions at the time that the `Keypair` is created. Open to suggestions here.

Fixes: https://github.com/sigstore/sigstore-go/issues/426

#### Release Note

Breaking change to the public `Keypair` interface
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
