### PR TITLE
go1.24.1, use 1024-bits key size in tests

### DIFF
--- a/examples/oci-image-verification/go.mod
+++ b/examples/oci-image-verification/go.mod
@@ -1,8 +1,6 @@
 module github.com/sigstore/sigstore-go/examples/oci-image-verification
 
-go 1.23.0
-
-toolchain go1.24.0
+go 1.24.1
 
 replace github.com/sigstore/sigstore-go => ../../
 

--- a/examples/oci-image-verification/go.sum
+++ b/examples/oci-image-verification/go.sum
@@ -103,8 +103,8 @@ github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nos
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/go-chi/chi v4.1.2+incompatible h1:fGFk2Gmi/YKXk0OmGfBh0WgmN3XB8lVnEyNz34tQRec=
 github.com/go-chi/chi v4.1.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
-github.com/go-jose/go-jose/v3 v3.0.3 h1:fFKWeig/irsp7XD2zBxvnmA/XaRWp5V3CBsZXJF7G7k=
-github.com/go-jose/go-jose/v3 v3.0.3/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQrVfLAMboGkQ=
+github.com/go-jose/go-jose/v3 v3.0.4 h1:Wp5HA7bLQcKnf6YYao/4kpRpVMp/yf6+pJKV8WFSaNY=
+github.com/go-jose/go-jose/v3 v3.0.4/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQrVfLAMboGkQ=
 github.com/go-jose/go-jose/v4 v4.0.5 h1:M6T8+mKZl/+fNNuFHvGIzDz7BTLQPIounk/b9dw3AaE=
 github.com/go-jose/go-jose/v4 v4.0.5/go.mod h1:s3P1lRrkT8igV8D9OjyL4WRyHvjB6a4JSllnOrmmBOA=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/sigstore/sigstore-go
 
-go 1.23.0
-
-toolchain go1.24.0
+go 1.24.1
 
 require (
 	github.com/cyberphone/json-canonicalization v0.0.0-20220623050100-57a0ce2678a7

--- a/pkg/bundle/bundle_test.go
+++ b/pkg/bundle/bundle_test.go
@@ -575,9 +575,9 @@ func TestVerificationContent(t *testing.T) {
 	leafCert := &x509.Certificate{
 		SerialNumber: big.NewInt(2),
 	}
-	caKey, err := rsa.GenerateKey(rand.Reader, 512) //nolint:gosec
+	caKey, err := rsa.GenerateKey(rand.Reader, 1024) //nolint:gosec
 	require.NoError(t, err)
-	leafKey, err := rsa.GenerateKey(rand.Reader, 512) //nolint:gosec
+	leafKey, err := rsa.GenerateKey(rand.Reader, 1024) //nolint:gosec
 	require.NoError(t, err)
 	caDer, err := x509.CreateCertificate(rand.Reader, caCert, caCert, &caKey.PublicKey, caKey)
 	require.NoError(t, err)


### PR DESCRIPTION
#### Summary
Update go to `1.24.1`, modify `TestVerificationContent` in pkg/bundle/bundle_test.go to use 1024-bit keys to avoid the errors due to the current [minimum key size])(https://pkg.go.dev/crypto/rsa#hdr-Minimum_key_size).

#### Release Note
NONE

#### Documentation
n/a
