### PR TITLE
Add support for verifying multiple artifacts

### DIFF
--- a/pkg/verify/fuzz_test.go
+++ b/pkg/verify/fuzz_test.go
@@ -16,6 +16,7 @@ package verify_test
 
 import (
 	"bytes"
+	"io"
 	"testing"
 
 	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
@@ -189,12 +190,12 @@ func FuzzVerifySignatureWithArtifactWithoutDigest(f *testing.F) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		artifact := bytes.NewReader(artifactBytes)
+		artifacts := []io.Reader{bytes.NewReader(artifactBytes)}
 		//nolint:errcheck
-		verify.VerifySignatureWithArtifact(sigContent,
+		verify.VerifySignatureWithArtifacts(sigContent,
 			verificationContent,
 			virtualSigstore,
-			artifact)
+			artifacts)
 	})
 }
 
@@ -225,11 +226,14 @@ func FuzzVerifySignatureWithArtifactDigest(f *testing.F) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		artifactDigests := []verify.ArtifactDigest{{
+			Algorithm: artifactDigestAlgorithm,
+			Digest:    artifactDigest,
+		}}
 		//nolint:errcheck
-		verify.VerifySignatureWithArtifactDigest(sigContent,
+		verify.VerifySignatureWithArtifactDigests(sigContent,
 			verificationContent,
 			virtualSigstore,
-			artifactDigest,
-			artifactDigestAlgorithm)
+			artifactDigests)
 	})
 }

--- a/pkg/verify/signature.go
+++ b/pkg/verify/signature.go
@@ -208,7 +208,7 @@ func verifyEnvelopeWithArtifacts(verifier signature.Verifier, envelope EnvelopeC
 	// created using that hash algorithm
 	subjectDigests := make(map[crypto.Hash][][]byte)
 	for _, subject := range statement.Subject {
-		for alg, digest := range subject.Digest {
+		for alg, hexdigest := range subject.Digest {
 			hf, err := algStringToHashFunc(alg)
 			if err != nil {
 				continue
@@ -216,11 +216,11 @@ func verifyEnvelopeWithArtifacts(verifier signature.Verifier, envelope EnvelopeC
 			if _, ok := subjectDigests[hf]; !ok {
 				subjectDigests[hf] = make([][]byte, 0)
 			}
-			hexdigest, err := hex.DecodeString(digest)
+			digest, err := hex.DecodeString(hexdigest)
 			if err != nil {
-				return fmt.Errorf("could not verify artifact: unable to decode subject digest: %w", err)
+				continue
 			}
-			subjectDigests[hf] = append(subjectDigests[hf], hexdigest)
+			subjectDigests[hf] = append(subjectDigests[hf], digest)
 		}
 	}
 

--- a/pkg/verify/signature.go
+++ b/pkg/verify/signature.go
@@ -283,7 +283,7 @@ func verifyEnvelopeWithArtifacts(verifier signature.Verifier, envelope EnvelopeC
 		for key, value := range ha {
 			statementDigests, ok := subjectDigests[key]
 			if !ok {
-				return fmt.Errorf("provided artifact digest does not match any digest in statement")
+				return fmt.Errorf("provided artifact digests do not match digests in statement")
 			}
 			matchFound := false
 			for _, sd := range statementDigests {
@@ -294,7 +294,7 @@ func verifyEnvelopeWithArtifacts(verifier signature.Verifier, envelope EnvelopeC
 				}
 			}
 			if !matchFound {
-				return fmt.Errorf("provided artifact digest does not match any digest in statement")
+				return fmt.Errorf("provided artifact digests do not match digests in statement")
 			}
 		}
 	}
@@ -366,7 +366,7 @@ func verifyEnvelopeWithArtifactDigests(verifier signature.Verifier, envelope Env
 	for _, artifactDigest := range digests {
 		statementDigests, ok := subjectDigests[artifactDigest.Algorithm]
 		if !ok {
-			return fmt.Errorf("provided artifact digest does not match any digest in statement")
+			return fmt.Errorf("provided artifact digests does not match digests in statement")
 		}
 
 		matchFound := false

--- a/pkg/verify/signature.go
+++ b/pkg/verify/signature.go
@@ -253,9 +253,9 @@ func verifyEnvelopeWithArtifacts(verifier signature.Verifier, envelope EnvelopeC
 		hashedArtifacts[i] = hasher.Sum(nil)
 	}
 
-	// create a map based on algorithms and digests found in the statement
-	// the key is the algorithm and the field is a slice of digests
-	// associated with that key
+	// create a map based on the digests present in the statement
+	// the map key is the hash algorithm and the field is a slice of digests
+	// created using that hash algorithm
 	subjectDigests := make(map[crypto.Hash][][]byte)
 	for _, subject := range statement.Subject {
 		for alg, digest := range subject.Digest {
@@ -338,9 +338,9 @@ func verifyEnvelopeWithArtifactDigests(verifier signature.Verifier, envelope Env
 		return err
 	}
 
-	// create a map based on algorithms and digests found in the statement
-	// the key is the algorithm and the field is a slice of digests
-	// associated with that key
+	// create a map based on the digests present in the statement
+	// the map key is the hash algorithm and the field is a slice of digests
+	// created using that hash algorithm
 	subjectDigests := make(map[string][][]byte)
 	for _, subject := range statement.Subject {
 		for alg, digest := range subject.Digest {

--- a/pkg/verify/signature.go
+++ b/pkg/verify/signature.go
@@ -67,7 +67,8 @@ func VerifySignatureWithArtifact(sigContent SignatureContent, verificationConten
 	}
 
 	if envelope := sigContent.EnvelopeContent(); envelope != nil {
-		return verifyEnvelopeWithArtifact(verifier, envelope, artifact)
+		artifacts := []io.Reader{artifact}
+		return verifyEnvelopeWithArtifacts(verifier, envelope, artifacts)
 	} else if msg := sigContent.MessageSignatureContent(); msg != nil {
 		return verifyMessageSignature(verifier, msg, artifact)
 	}
@@ -100,7 +101,13 @@ func VerifySignatureWithArtifactDigest(sigContent SignatureContent, verification
 	}
 
 	if envelope := sigContent.EnvelopeContent(); envelope != nil {
-		return verifyEnvelopeWithArtifactDigest(verifier, envelope, artifactDigest, artifactDigestAlgorithm)
+		ad := ArtifactDigest{
+			Algorithm: artifactDigestAlgorithm,
+			Digest:    artifactDigest,
+		}
+		artifactDigests := []ArtifactDigest{ad}
+
+		return verifyEnvelopeWithArtifactDigests(verifier, envelope, artifactDigests)
 	} else if msg := sigContent.MessageSignatureContent(); msg != nil {
 		return verifyMessageSignatureWithArtifactDigest(verifier, msg, artifactDigest)
 	}
@@ -161,11 +168,6 @@ func verifyEnvelope(verifier signature.Verifier, envelope EnvelopeContent) error
 	}
 
 	return nil
-}
-
-func verifyEnvelopeWithArtifact(verifier signature.Verifier, envelope EnvelopeContent, artifact io.Reader) error {
-	artifacts := []io.Reader{artifact}
-	return verifyEnvelopeWithArtifacts(verifier, envelope, artifacts)
 }
 
 func verifyEnvelopeWithArtifacts(verifier signature.Verifier, envelope EnvelopeContent, artifacts []io.Reader) error {
@@ -245,15 +247,6 @@ func verifyEnvelopeWithArtifacts(verifier signature.Verifier, envelope EnvelopeC
 	}
 
 	return nil
-}
-
-func verifyEnvelopeWithArtifactDigest(verifier signature.Verifier, envelope EnvelopeContent, artifactDigest []byte, artifactDigestAlgorithm string) error {
-	ad := ArtifactDigest{
-		Algorithm: artifactDigestAlgorithm,
-		Digest:    artifactDigest,
-	}
-	artifactDigests := []ArtifactDigest{ad}
-	return verifyEnvelopeWithArtifactDigests(verifier, envelope, artifactDigests)
 }
 
 func verifyEnvelopeWithArtifactDigests(verifier signature.Verifier, envelope EnvelopeContent, digests []ArtifactDigest) error {

--- a/pkg/verify/signature.go
+++ b/pkg/verify/signature.go
@@ -88,19 +88,17 @@ func VerifySignatureWithArtifactDigests(sigContent SignatureContent, verificatio
 	}
 
 	envelope := sigContent.EnvelopeContent()
-	// If there is only one artifact and no envelope,
-	// attempt to verify the message signature with the artifact.
-	if len(digests) == 1 && envelope == nil {
-		if msg := sigContent.MessageSignatureContent(); msg != nil {
-			return verifyMessageSignatureWithArtifactDigest(verifier, msg, digests[0].Digest)
-		}
+	msg := sigContent.MessageSignatureContent()
+	if envelope == nil && msg == nil {
 		return fmt.Errorf("signature content has neither an envelope or a message")
 	}
-
-	// If there is no envelope, return an error.
+	// If there is only one artifact and no envelope,
+	// attempt to verify the message signature with the artifact.
 	if envelope == nil {
-		// handle an invalid signature content message
-		return fmt.Errorf("signature content does not have an envelope")
+		if len(digests) != 1 {
+			return fmt.Errorf("only one artifact can be verified with a message signature")
+		}
+		return verifyMessageSignatureWithArtifactDigest(verifier, msg, digests[0].Digest)
 	}
 
 	return verifyEnvelopeWithArtifactDigests(verifier, envelope, digests)

--- a/pkg/verify/signature_test.go
+++ b/pkg/verify/signature_test.go
@@ -236,4 +236,17 @@ func TestVerifyEnvelopeWithMultipleArtifactsAndArtifactDigests(t *testing.T) {
 
 	_, err = verifier.Verify(entity, verify.NewPolicy(verify.WithArtifactDigests(artifactDigests), verify.WithoutIdentitiesUnsafe()))
 	assert.NoError(t, err)
+
+	noMatchingArtifacts := []io.Reader{strings.NewReader("some other artifact")}
+	_, err = verifier.Verify(entity, verify.NewPolicy(verify.WithArtifacts(noMatchingArtifacts), verify.WithoutIdentitiesUnsafe()))
+	assert.Error(t, err)
+
+	noMatchingArtifactDigests := []verify.ArtifactDigest{
+		{
+			Algorithm: "sha256",
+			Digest:    []byte("some other artifact"),
+		},
+	}
+	_, err = verifier.Verify(entity, verify.NewPolicy(verify.WithArtifactDigests(noMatchingArtifactDigests), verify.WithoutIdentitiesUnsafe()))
+	assert.Error(t, err)
 }

--- a/pkg/verify/signature_test.go
+++ b/pkg/verify/signature_test.go
@@ -155,11 +155,10 @@ func TestTooManyDigests(t *testing.T) {
 	tooManyDigestsStatement := in_toto.Statement{}
 	tooManyDigestsStatement.Subject = []in_toto.Subject{
 		{
-			Name:   fmt.Sprintf("subject"),
+			Name:   "subject",
 			Digest: make(common.DigestSet),
 		},
 	}
-	// does sigstore-go already map multiple digests to a single digest algorithm key?
 	tooManyDigestsStatement.Subject[0].Digest["sha512"] = "" // verifier requires that at least one known hash algorithm is present in the digest map
 	for i := 0; i < 32; i++ {
 		tooManyDigestsStatement.Subject[0].Digest[fmt.Sprintf("digest-%d", i)] = ""
@@ -186,12 +185,15 @@ func TestVerifyEnvelopeWithArtifacts(t *testing.T) {
 	subjectBodies := make([]io.Reader, 10)
 	subjects := make([]in_toto.Subject, 10)
 	artifactDigests := make([]verify.ArtifactDigest, 10)
+	// Create ten test subjects
 	for i := range 10 {
 		s := in_toto.Subject{
 			Name: fmt.Sprintf("subject-%d", i),
 		}
 		subjectBody := fmt.Sprintf("Hi, I am a subject! #%d", i)
 		subjectBodies[i] = strings.NewReader(subjectBody)
+		// alternate between sha256 and sha512 when creating the digests
+		// so that we can test that the verifier can handle multiple digest algorithms
 		if i%2 == 0 {
 			digest256 := sha256.Sum256([]byte(subjectBody))
 			digest := digest256[:]

--- a/pkg/verify/signed_entity.go
+++ b/pkg/verify/signed_entity.go
@@ -493,7 +493,7 @@ func WithArtifacts(artifacts []io.Reader) ArtifactPolicyOption {
 		}
 
 		if p.weDoNotExpectAnArtifact {
-			return errors.New("can't use WithArtifact while using WithoutArtifactUnsafe")
+			return errors.New("can't use WithArtifacts while using WithoutArtifactUnsafe")
 		}
 
 		p.verifyArtifacts = true
@@ -542,7 +542,7 @@ func WithArtifactDigests(digests []ArtifactDigest) ArtifactPolicyOption {
 		}
 
 		if p.weDoNotExpectAnArtifact {
-			return errors.New("can't use WithArtifactDigest while using WithoutArtifactUnsafe")
+			return errors.New("can't use WithArtifactDigests while using WithoutArtifactUnsafe")
 		}
 
 		p.verifyArtifactDigests = true
@@ -666,6 +666,8 @@ func (v *SignedEntityVerifier) Verify(entity SignedEntity, pb PolicyBuilder) (*V
 		switch {
 		case policy.verifyArtifact:
 			err = VerifySignatureWithArtifact(sigContent, verificationContent, v.trustedMaterial, policy.artifact)
+		case policy.verifyArtifacts:
+			err = VerifySignatureWithArtifacts(sigContent, verificationContent, v.trustedMaterial, policy.artifacts)
 		case policy.verifyArtifactDigest:
 			err = VerifySignatureWithArtifactDigest(sigContent, verificationContent, v.trustedMaterial, policy.artifactDigest, policy.artifactDigestAlgorithm)
 		case policy.verifyArtifactDigests:

--- a/pkg/verify/signed_entity.go
+++ b/pkg/verify/signed_entity.go
@@ -310,6 +310,14 @@ type PolicyConfig struct {
 	artifactDigestAlgorithm string
 }
 
+func (p *PolicyConfig) withVerifyAlreadyConfigured() error {
+	if p.verifyArtifact || p.verifyArtifacts || p.verifyArtifactDigest || p.verifyArtifactDigests {
+		return errors.New("only one invocation of WithArtifact/WithArtifacts/WithArtifactDigest/WithArtifactDigests is allowed")
+	}
+
+	return nil
+}
+
 func (p *PolicyConfig) Validate() error {
 	if p.WeExpectIdentities() && len(p.certificateIdentities) == 0 {
 		return errors.New("can't verify identities without providing at least one identity")
@@ -441,8 +449,8 @@ func WithKey() PolicyOption {
 // an artifact.
 func WithoutArtifactUnsafe() ArtifactPolicyOption {
 	return func(p *PolicyConfig) error {
-		if p.verifyArtifact || p.verifyArtifactDigest {
-			return errors.New("can't use WithoutArtifactUnsafe while using WithArtifact or WithArtifactDigest")
+		if err := p.withVerifyAlreadyConfigured(); err != nil {
+			return err
 		}
 
 		p.weDoNotExpectAnArtifact = true
@@ -458,8 +466,8 @@ func WithoutArtifactUnsafe() ArtifactPolicyOption {
 // envelope's statement.
 func WithArtifact(artifact io.Reader) ArtifactPolicyOption {
 	return func(p *PolicyConfig) error {
-		if p.verifyArtifact || p.verifyArtifactDigest {
-			return errors.New("only one invocation of WithArtifact/WithArtifactDigest is allowed")
+		if err := p.withVerifyAlreadyConfigured(); err != nil {
+			return err
 		}
 
 		if p.weDoNotExpectAnArtifact {
@@ -480,8 +488,8 @@ func WithArtifact(artifact io.Reader) ArtifactPolicyOption {
 // envelope's statement.
 func WithArtifacts(artifacts []io.Reader) ArtifactPolicyOption {
 	return func(p *PolicyConfig) error {
-		if p.verifyArtifact || p.verifyArtifacts || p.verifyArtifactDigest {
-			return errors.New("only one invocation of WithArtifact/WithArtifactDigest is allowed")
+		if err := p.withVerifyAlreadyConfigured(); err != nil {
+			return err
 		}
 
 		if p.weDoNotExpectAnArtifact {
@@ -505,8 +513,8 @@ func WithArtifacts(artifacts []io.Reader) ArtifactPolicyOption {
 // compared to the digest in the envelope's statement.
 func WithArtifactDigest(algorithm string, artifactDigest []byte) ArtifactPolicyOption {
 	return func(p *PolicyConfig) error {
-		if p.verifyArtifact || p.verifyArtifactDigest {
-			return errors.New("only one invocation of WithArtifact/WithArtifactDigest is allowed")
+		if err := p.withVerifyAlreadyConfigured(); err != nil {
+			return err
 		}
 
 		if p.weDoNotExpectAnArtifact {
@@ -529,8 +537,8 @@ func WithArtifactDigest(algorithm string, artifactDigest []byte) ArtifactPolicyO
 // If the SignedEntity does not contain a DSSE envelope, verification fails.
 func WithArtifactDigests(digests []ArtifactDigest) ArtifactPolicyOption {
 	return func(p *PolicyConfig) error {
-		if p.verifyArtifact || p.verifyArtifactDigest || p.verifyArtifactDigests {
-			return errors.New("only one invocation of WithArtifact/WithArtifactDigest is allowed")
+		if err := p.withVerifyAlreadyConfigured(); err != nil {
+			return err
 		}
 
 		if p.weDoNotExpectAnArtifact {


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Closes https://github.com/sigstore/sigstore-go/issues/363

This adds support for verifying multiple artifacts against in-toto statement subjects. I added `verify.WithArtifacts(artifacts []io.Reader)` and `verify.WithArtifactDigests([]ArtifactDigest)`.

To avoid creating nested for loops when checking for the presence of artifacts in the intoto statement, I utilized maps to store subjects stored in the statement by hash algorithm.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
