### PR TITLE
Fix lint errors, standardize policy language

### DIFF
--- a/pkg/fulcio/certificate/summarize.go
+++ b/pkg/fulcio/certificate/summarize.go
@@ -58,7 +58,7 @@ func SummarizeCertificate(cert *x509.Certificate) (Summary, error) {
 		san, _ = cryptoutils.UnmarshalOtherNameSAN(cert.Extensions)
 	}
 	if san == "" {
-		return Summary{}, errors.New("No Subject Alternative Name found")
+		return Summary{}, errors.New("no Subject Alternative Name found")
 	}
 
 	return Summary{CertificateIssuer: cert.Issuer.String(), SubjectAlternativeName: san, Extensions: extensions}, nil

--- a/pkg/root/trusted_root.go
+++ b/pkg/root/trusted_root.go
@@ -453,22 +453,19 @@ func NewLiveTrustedRoot(opts *tuf.Options) (*LiveTrustedRoot, error) {
 	}
 	ticker := time.NewTicker(time.Hour * 24)
 	go func() {
-		for {
-			select {
-			case <-ticker.C:
-				client, err = tuf.New(opts)
-				if err != nil {
-					log.Printf("error creating TUF client: %v", err)
-				}
-				newTr, err := GetTrustedRoot(client)
-				if err != nil {
-					log.Printf("error fetching trusted root: %v", err)
-					continue
-				}
-				ltr.mu.Lock()
-				ltr.TrustedRoot = newTr
-				ltr.mu.Unlock()
+		for range ticker.C {
+			client, err = tuf.New(opts)
+			if err != nil {
+				log.Printf("error creating TUF client: %v", err)
 			}
+			newTr, err := GetTrustedRoot(client)
+			if err != nil {
+				log.Printf("error fetching trusted root: %v", err)
+				continue
+			}
+			ltr.mu.Lock()
+			ltr.TrustedRoot = newTr
+			ltr.mu.Unlock()
 		}
 	}()
 	return ltr, nil

--- a/pkg/sign/certificate.go
+++ b/pkg/sign/certificate.go
@@ -107,7 +107,7 @@ func NewFulcio(opts *FulcioOptions) *Fulcio {
 // Returns DER-encoded code signing certificate
 func (f *Fulcio) GetCertificate(ctx context.Context, keypair Keypair, opts *CertificateProviderOptions) ([]byte, error) {
 	if opts.IDToken == "" {
-		return nil, errors.New("Fulcio requires IDToken to be set")
+		return nil, errors.New("fetching certificate from Fulcio requires IDToken to be set")
 	}
 
 	// Get JWT from identity token
@@ -116,7 +116,7 @@ func (f *Fulcio) GetCertificate(ctx context.Context, keypair Keypair, opts *Cert
 	// the token verification.
 	tokenParts := strings.Split(opts.IDToken, ".")
 	if len(tokenParts) < 2 {
-		return nil, errors.New("Unable to get subject from identity token")
+		return nil, errors.New("unable to get subject from identity token")
 	}
 
 	jwtString, err := base64.RawURLEncoding.DecodeString(tokenParts[1])

--- a/pkg/sign/keys.go
+++ b/pkg/sign/keys.go
@@ -109,7 +109,7 @@ func getHashFunc(hashAlgorithm protocommon.HashAlgorithm) (crypto.Hash, error) {
 		return crypto.Hash(crypto.SHA512), nil
 	default:
 		var hash crypto.Hash
-		return hash, errors.New("Unsupported hash algorithm")
+		return hash, errors.New("unsupported hash algorithm")
 	}
 }
 

--- a/pkg/sign/signer.go
+++ b/pkg/sign/signer.go
@@ -54,7 +54,7 @@ type BundleOptions struct {
 
 func Bundle(content Content, keypair Keypair, opts BundleOptions) (*protobundle.Bundle, error) {
 	if keypair == nil {
-		return nil, errors.New("Must provide a keypair for signing, like EphemeralKeypair")
+		return nil, errors.New("must provide a keypair for signing, like EphemeralKeypair")
 	}
 
 	if opts.Context == nil {

--- a/pkg/sign/timestamping.go
+++ b/pkg/sign/timestamping.go
@@ -112,7 +112,7 @@ func (ta *TimestampAuthority) GetTimestamp(ctx context.Context, signature []byte
 	}
 
 	if response.StatusCode != 200 && response.StatusCode != 201 {
-		return nil, fmt.Errorf("Timestamp authority returned %d: %s", response.StatusCode, string(body))
+		return nil, fmt.Errorf("timestamp authority returned %d: %s", response.StatusCode, string(body))
 	}
 
 	_, err = timestamp.ParseResponse(body)

--- a/pkg/testing/data/data.go
+++ b/pkg/testing/data/data.go
@@ -16,7 +16,6 @@ package data
 
 import (
 	"embed"
-	_ "embed"
 	"path"
 	"testing"
 

--- a/pkg/verify/signed_entity.go
+++ b/pkg/verify/signed_entity.go
@@ -266,7 +266,7 @@ type PolicyBuilder struct {
 	policyOptions  []PolicyOption
 }
 
-func (pc PolicyBuilder) Options() []PolicyOption {
+func (pc PolicyBuilder) options() []PolicyOption {
 	arr := []PolicyOption{PolicyOption(pc.artifactPolicy)}
 	return append(arr, pc.policyOptions...)
 }
@@ -275,14 +275,14 @@ func (pc PolicyBuilder) BuildConfig() (*PolicyConfig, error) {
 	var err error
 
 	policy := &PolicyConfig{}
-	for _, applyOption := range pc.Options() {
+	for _, applyOption := range pc.options() {
 		err = applyOption(policy)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	if err := policy.Validate(); err != nil {
+	if err := policy.validate(); err != nil {
 		return nil, err
 	}
 
@@ -295,14 +295,14 @@ type ArtifactDigest struct {
 }
 
 type PolicyConfig struct {
-	ignoreArtifact          bool
-	ignoreIdentities        bool
-	requireSigningKey       bool
-	certificateIdentities   CertificateIdentities
-	verifyArtifacts         bool
-	artifacts               []io.Reader
-	verifyArtifactDigests   bool
-	artifactDigests         []ArtifactDigest
+	ignoreArtifact        bool
+	ignoreIdentities      bool
+	requireSigningKey     bool
+	certificateIdentities CertificateIdentities
+	verifyArtifacts       bool
+	artifacts             []io.Reader
+	verifyArtifactDigests bool
+	artifactDigests       []ArtifactDigest
 }
 
 func (p *PolicyConfig) withVerifyAlreadyConfigured() error {
@@ -313,7 +313,7 @@ func (p *PolicyConfig) withVerifyAlreadyConfigured() error {
 	return nil
 }
 
-func (p *PolicyConfig) Validate() error {
+func (p *PolicyConfig) validate() error {
 	if p.RequireIdentities() && len(p.certificateIdentities) == 0 {
 		return errors.New("can't verify identities without providing at least one identity")
 	}
@@ -486,7 +486,7 @@ func WithArtifacts(artifacts []io.Reader) ArtifactPolicyOption {
 			return err
 		}
 
-		if p.weDoNotExpectAnArtifact {
+		if p.ignoreArtifact {
 			return errors.New("can't use WithArtifacts while using WithoutArtifactUnsafe")
 		}
 
@@ -537,7 +537,7 @@ func WithArtifactDigests(digests []ArtifactDigest) ArtifactPolicyOption {
 			return err
 		}
 
-		if p.weDoNotExpectAnArtifact {
+		if p.ignoreArtifact {
 			return errors.New("can't use WithArtifactDigests while using WithoutArtifactUnsafe")
 		}
 

--- a/pkg/verify/signed_entity.go
+++ b/pkg/verify/signed_entity.go
@@ -295,9 +295,9 @@ type ArtifactDigest struct {
 }
 
 type PolicyConfig struct {
-	weDoNotExpectAnArtifact bool
-	weDoNotExpectIdentities bool
-	weExpectSigningKey      bool
+	ignoreArtifact          bool
+	ignoreIdentities        bool
+	requireSigningKey       bool
 	certificateIdentities   CertificateIdentities
 	verifyArtifacts         bool
 	artifacts               []io.Reader
@@ -314,47 +314,46 @@ func (p *PolicyConfig) withVerifyAlreadyConfigured() error {
 }
 
 func (p *PolicyConfig) Validate() error {
-	if p.WeExpectIdentities() && len(p.certificateIdentities) == 0 {
+	if p.RequireIdentities() && len(p.certificateIdentities) == 0 {
 		return errors.New("can't verify identities without providing at least one identity")
 	}
 
 	return nil
 }
 
-// WeExpectAnArtifact returns true if the Verify algorithm should perform
+// RequireArtifact returns true if the Verify algorithm should perform
 // signature verification with an an artifact provided by either the
 // WithArtifact or the WithArtifactDigest functions.
 //
 // By default, unless explicitly turned off, we should always expect to verify
 // a SignedEntity's signature using an artifact. Bools are initialized to false,
-// so this behaviour is therefore controlled by the weDoNotExpectAnArtifact
-// field.
+// so this behaviour is therefore controlled by the ignoreArtifact field.
 //
 // Double negatives are confusing, though. To aid with comprehension of the
 // main Verify loop, this function therefore just wraps the double negative.
-func (p *PolicyConfig) WeExpectAnArtifact() bool {
-	return !p.weDoNotExpectAnArtifact
+func (p *PolicyConfig) RequireArtifact() bool {
+	return !p.ignoreArtifact
 }
 
-// WeExpectIdentities returns true if the Verify algorithm should check
+// RequireIdentities returns true if the Verify algorithm should check
 // whether the SignedEntity's certificate was created by one of the identities
 // provided by the WithCertificateIdentity function.
 //
 // By default, unless explicitly turned off, we should always expect to enforce
 // that a SignedEntity's certificate was created by an Identity we trust. Bools
 // are initialized to false, so this behaviour is therefore controlled by the
-// weDoNotExpectIdentities field.
+// ignoreIdentities field.
 //
 // Double negatives are confusing, though. To aid with comprehension of the
 // main Verify loop, this function therefore just wraps the double negative.
-func (p *PolicyConfig) WeExpectIdentities() bool {
-	return !p.weDoNotExpectIdentities
+func (p *PolicyConfig) RequireIdentities() bool {
+	return !p.ignoreIdentities
 }
 
-// WeExpectSigningKey returns true if we expect the SignedEntity to be signed
+// RequireSigningKey returns true if we expect the SignedEntity to be signed
 // with a key and not a certificate.
-func (p *PolicyConfig) WeExpectSigningKey() bool {
-	return p.weExpectSigningKey
+func (p *PolicyConfig) RequireSigningKey() bool {
+	return p.requireSigningKey
 }
 
 func NewPolicy(artifactOpt ArtifactPolicyOption, options ...PolicyOption) PolicyBuilder {
@@ -377,7 +376,7 @@ func WithoutIdentitiesUnsafe() PolicyOption {
 			return errors.New("can't use WithoutIdentitiesUnsafe while specifying CertificateIdentities")
 		}
 
-		p.weDoNotExpectIdentities = true
+		p.ignoreIdentities = true
 		return nil
 	}
 }
@@ -402,10 +401,10 @@ func WithoutIdentitiesUnsafe() PolicyOption {
 // For convenience, consult the NewShortCertificateIdentity function.
 func WithCertificateIdentity(identity CertificateIdentity) PolicyOption {
 	return func(p *PolicyConfig) error {
-		if p.weDoNotExpectIdentities {
+		if p.ignoreIdentities {
 			return errors.New("can't use WithCertificateIdentity while using WithoutIdentitiesUnsafe")
 		}
-		if p.weExpectSigningKey {
+		if p.requireSigningKey {
 			return errors.New("can't use WithCertificateIdentity while using WithKey")
 		}
 
@@ -422,8 +421,8 @@ func WithKey() PolicyOption {
 			return errors.New("can't use WithKey while using WithCertificateIdentity")
 		}
 
-		p.weExpectSigningKey = true
-		p.weDoNotExpectIdentities = true
+		p.requireSigningKey = true
+		p.ignoreIdentities = true
 		return nil
 	}
 }
@@ -448,7 +447,7 @@ func WithoutArtifactUnsafe() ArtifactPolicyOption {
 			return err
 		}
 
-		p.weDoNotExpectAnArtifact = true
+		p.ignoreArtifact = true
 		return nil
 	}
 }
@@ -465,7 +464,7 @@ func WithArtifact(artifact io.Reader) ArtifactPolicyOption {
 			return err
 		}
 
-		if p.weDoNotExpectAnArtifact {
+		if p.ignoreArtifact {
 			return errors.New("can't use WithArtifact while using WithoutArtifactUnsafe")
 		}
 
@@ -512,7 +511,7 @@ func WithArtifactDigest(algorithm string, artifactDigest []byte) ArtifactPolicyO
 			return err
 		}
 
-		if p.weDoNotExpectAnArtifact {
+		if p.ignoreArtifact {
 			return errors.New("can't use WithArtifactDigest while using WithoutArtifactUnsafe")
 		}
 
@@ -599,7 +598,7 @@ func (v *SignedEntityVerifier) Verify(entity SignedEntity, pb PolicyBuilder) (*V
 	// If the bundle was signed with a long-lived key, and does not have a Fulcio certificate,
 	// then skip the certificate verification steps
 	if leafCert := verificationContent.Certificate(); leafCert != nil {
-		if policy.WeExpectSigningKey() {
+		if policy.RequireSigningKey() {
 			return nil, errors.New("expected key signature, not certificate")
 		}
 
@@ -659,7 +658,7 @@ func (v *SignedEntityVerifier) Verify(entity SignedEntity, pb PolicyBuilder) (*V
 		return nil, fmt.Errorf("failed to fetch signature content: %w", err)
 	}
 
-	if policy.WeExpectAnArtifact() {
+	if policy.RequireArtifact() {
 		switch {
 		case policy.verifyArtifacts:
 			err = VerifySignatureWithArtifacts(sigContent, verificationContent, v.trustedMaterial, policy.artifacts)
@@ -708,7 +707,7 @@ func (v *SignedEntityVerifier) Verify(entity SignedEntity, pb PolicyBuilder) (*V
 
 	// From ## Certificate section,
 	// >The Verifier MUST then check the certificate against the verification policy. Details on how to do this depend on the verification policy, but the Verifier SHOULD check the Issuer X.509 extension (OID 1.3.6.1.4.1.57264.1.1) at a minimum, and will in most cases check the SubjectAlternativeName as well. See  Spec: Fulcio §TODO for example checks on the certificate.
-	if policy.WeExpectIdentities() {
+	if policy.RequireIdentities() {
 		if !signedWithCertificate {
 			// We got asked to verify identities, but the entity was not signed with
 			// a certificate. That's a problem!

--- a/pkg/verify/signed_entity_test.go
+++ b/pkg/verify/signed_entity_test.go
@@ -249,8 +249,8 @@ func TestVerifyPolicyOptionErors(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, p)
 
-	assert.False(t, p.WeExpectAnArtifact())
-	assert.True(t, p.WeExpectIdentities())
+	assert.False(t, p.RequireArtifact())
+	assert.True(t, p.RequireIdentities())
 
 	// ---
 
@@ -259,8 +259,8 @@ func TestVerifyPolicyOptionErors(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, p)
 
-	assert.False(t, p.WeExpectAnArtifact())
-	assert.False(t, p.WeExpectIdentities())
+	assert.False(t, p.RequireArtifact())
+	assert.False(t, p.RequireIdentities())
 
 	// ---
 
@@ -269,8 +269,8 @@ func TestVerifyPolicyOptionErors(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, p)
 
-	assert.True(t, p.WeExpectAnArtifact())
-	assert.False(t, p.WeExpectIdentities())
+	assert.True(t, p.RequireArtifact())
+	assert.False(t, p.RequireIdentities())
 
 	// ---
 
@@ -279,8 +279,8 @@ func TestVerifyPolicyOptionErors(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, p)
 
-	assert.True(t, p.WeExpectSigningKey())
-	assert.False(t, p.WeExpectIdentities())
+	assert.True(t, p.RequireSigningKey())
+	assert.False(t, p.RequireIdentities())
 
 	// let's exercise the different error cases!
 	// 1. can't combine WithoutArtifactUnsafe with other Artifact options


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Small cleanup of linting errors, and standardizing policy language around Require/Ignore to be in sync with VerifierConfig.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

* Renamed PolicyConfig methods and unexported PolicyConfig validation. Clients are not expected to directly use these methods.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
