### PR TITLE
Added a new function to create a live trusted root from any target.

### DIFF
--- a/pkg/root/trusted_root.go
+++ b/pkg/root/trusted_root.go
@@ -57,6 +57,10 @@ type TransparencyLog struct {
 	SignatureHashFunc crypto.Hash
 }
 
+const (
+	defaultTrustedRoot = "trusted_root.json"
+)
+
 func (tr *TrustedRoot) TimestampingAuthorities() []TimestampingAuthority {
 	return tr.timestampingAuthorities
 }
@@ -397,7 +401,7 @@ func FetchTrustedRootWithOptions(opts *tuf.Options) (*TrustedRoot, error) {
 
 // GetTrustedRoot returns the trusted root
 func GetTrustedRoot(c *tuf.Client) (*TrustedRoot, error) {
-	jsonBytes, err := c.GetTarget("trusted_root.json")
+	jsonBytes, err := c.GetTarget(defaultTrustedRoot)
 	if err != nil {
 		return nil, err
 	}
@@ -439,11 +443,23 @@ type LiveTrustedRoot struct {
 // NewLiveTrustedRoot returns a LiveTrustedRoot that will periodically
 // refresh the trusted root from TUF.
 func NewLiveTrustedRoot(opts *tuf.Options) (*LiveTrustedRoot, error) {
+	return NewLiveTrustedRootFromTarget(opts, defaultTrustedRoot)
+}
+
+// NewLiveTrustedRootFromTarget returns a LiveTrustedRoot that will
+// periodically refresh the trusted root from TUF using the provided target.
+func NewLiveTrustedRootFromTarget(opts *tuf.Options, target string) (*LiveTrustedRoot, error) {
 	client, err := tuf.New(opts)
 	if err != nil {
 		return nil, err
 	}
-	tr, err := GetTrustedRoot(client)
+
+	b, err := client.GetTarget(target)
+	if err != nil {
+		return nil, err
+	}
+
+	tr, err := NewTrustedRootFromJSON(b)
 	if err != nil {
 		return nil, err
 	}
@@ -458,7 +474,13 @@ func NewLiveTrustedRoot(opts *tuf.Options) (*LiveTrustedRoot, error) {
 			if err != nil {
 				log.Printf("error creating TUF client: %v", err)
 			}
-			newTr, err := GetTrustedRoot(client)
+
+			b, err := client.GetTarget(target)
+			if err != nil {
+				log.Printf("error fetching trusted root: %v", err)
+			}
+
+			newTr, err := NewTrustedRootFromJSON(b)
 			if err != nil {
 				log.Printf("error fetching trusted root: %v", err)
 				continue


### PR DESCRIPTION


<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Added a new function for creating a live updated trusted root from a client controlled target.

#### Release Note

* Live trusted roots can now be created from any target
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
