### PR TITLE
root: Fix trusted root creation with ed25519 keys

### DIFF
--- a/pkg/root/trusted_root_create.go
+++ b/pkg/root/trusted_root_create.go
@@ -260,7 +260,7 @@ func publicKeyToProtobufPublicKey(publicKey crypto.PublicKey, start time.Time, e
 		default:
 			return nil, fmt.Errorf("unsupported public modulus for RSA key: %d", p.Size())
 		}
-	case *ed25519.PublicKey:
+	case ed25519.PublicKey:
 		pkd.KeyDetails = protocommon.PublicKeyDetails_PKIX_ED25519
 	default:
 		return nil, fmt.Errorf("unknown public key type: %T", p)

--- a/pkg/root/trusted_root_test.go
+++ b/pkg/root/trusted_root_test.go
@@ -92,6 +92,13 @@ func TestTrustedMaterialCollectionECDSA(t *testing.T) {
 	verifier2, err := trustedMaterialCollection.PublicKeyVerifier("foo")
 	assert.NoError(t, err)
 	assert.Equal(t, verifier, verifier2)
+
+	// verify that a JSON round trip works
+	jsonBytes, err := json.Marshal(trustedRoot)
+	assert.NoError(t, err)
+
+	_, err = NewTrustedRootFromJSON(jsonBytes)
+	assert.NoError(t, err)
 }
 
 func TestTrustedMaterialCollectionED25519(t *testing.T) {
@@ -131,6 +138,13 @@ func TestTrustedMaterialCollectionED25519(t *testing.T) {
 	verifier2, err := trustedMaterialCollection.PublicKeyVerifier("foo")
 	assert.NoError(t, err)
 	assert.Equal(t, verifier, verifier2)
+
+	// verify that a JSON round trip works
+	jsonBytes, err := json.Marshal(trustedRoot)
+	assert.NoError(t, err)
+
+	_, err = NewTrustedRootFromJSON(jsonBytes)
+	assert.NoError(t, err)
 }
 
 func TestTrustedMaterialCollectionRSA(t *testing.T) {
@@ -166,6 +180,13 @@ func TestTrustedMaterialCollectionRSA(t *testing.T) {
 	verifier2, err := trustedMaterialCollection.PublicKeyVerifier("foo")
 	assert.NoError(t, err)
 	assert.Equal(t, verifier, verifier2)
+
+	// verify that a JSON round trip works
+	jsonBytes, err := json.Marshal(trustedRoot)
+	assert.NoError(t, err)
+
+	_, err = NewTrustedRootFromJSON(jsonBytes)
+	assert.NoError(t, err)
 }
 
 func TestFromJSONToJSON(t *testing.T) {


### PR DESCRIPTION
This is golang being weird: unlike all other keys ed25519.PublicKey is not a struct, just bytes.

Without this fix `cosign trusted-root create` fails when used with a rekor public key of type ED25519:

```
Error: failed constructing protobuf TrustRoot representation: 
failed converting rekor log b409400995a452b89ff59f6c388ae99356a4d48f25a1136e7e4efd37a97548d8 to protobuf:
failed converting public key to protobuf:
unknown public key type: ed25519.PublicKey
```