### PR TITLE
don't return error if logIndex is 0

### DIFF
--- a/pkg/tlog/entry.go
+++ b/pkg/tlog/entry.go
@@ -101,7 +101,7 @@ func ParseEntry(protoEntry *v1.TransparencyLogEntry) (entry *Entry, err error) {
 	if protoEntry == nil ||
 		protoEntry.CanonicalizedBody == nil ||
 		protoEntry.IntegratedTime == 0 ||
-		protoEntry.LogIndex == 0 ||
+		protoEntry.LogIndex < 0 ||
 		protoEntry.LogId == nil ||
 		protoEntry.LogId.KeyId == nil ||
 		protoEntry.KindVersion == nil {


### PR DESCRIPTION
the first entry in a log is indexed at `0` so this is not an error; right now in proto we have this specified as an `int64` (even though a negative value is not possible and nonsensical) so changing this check to look for a negative number.