### PR TITLE
Add context parameter to verify.Verify()

### DIFF
--- a/docs/verification.md
+++ b/docs/verification.md
@@ -104,7 +104,7 @@ Then, we load the bundle and perform the verification:
 		panic(err)
 	}
 
-	result, err := sev.Verify(b, verify.NewPolicy(verify.WithArtifactDigest("sha512", digest), verify.WithCertificateIdentity(certID)))
+	result, err := sev.Verify(context.TODO(), b, verify.NewPolicy(verify.WithArtifactDigest("sha512", digest), verify.WithCertificateIdentity(certID)))
 	if err != nil {
 		panic(err)
 	}
@@ -180,6 +180,7 @@ Putting it together, the following script will verify the example bundle and pri
 package main
 
 import (
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -222,7 +223,7 @@ func main() {
 		panic(err)
 	}
 
-	result, err := sev.Verify(b, verify.NewPolicy(verify.WithArtifactDigest("sha512", digest), verify.WithCertificateIdentity(certID)))
+	result, err := sev.Verify(context.TODO(), b, verify.NewPolicy(verify.WithArtifactDigest("sha512", digest), verify.WithCertificateIdentity(certID)))
 	if err != nil {
 		panic(err)
 	}
@@ -241,6 +242,7 @@ And here is a complete example of verifying a bundle signed with a key:
 package main
 
 import (
+	"context"
 	"crypto"
 	_ "crypto/sha256"
 	"crypto/x509"
@@ -318,7 +320,7 @@ func main() {
 		panic(err)
 	}
 
-	result, err := sev.Verify(b, verify.NewPolicy(verify.WithArtifactDigest("sha512", digest), verify.WithKey()))
+	result, err := sev.Verify(context.TODO(), b, verify.NewPolicy(verify.WithArtifactDigest("sha512", digest), verify.WithKey()))
 	if err != nil {
 		panic(err)
 	}

--- a/examples/oci-image-verification/main.go
+++ b/examples/oci-image-verification/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/x509"
@@ -212,7 +213,7 @@ func run() error {
 		fmt.Fprintf(os.Stderr, "No artifact provided, skipping artifact verification. This is unsafe!\n")
 	}
 
-	res, err := sev.Verify(b, verify.NewPolicy(artifactPolicy, identityPolicies...))
+	res, err := sev.Verify(context.TODO(), b, verify.NewPolicy(artifactPolicy, identityPolicies...))
 	if err != nil {
 		return err
 	}

--- a/examples/sigstore-go-verification/main.go
+++ b/examples/sigstore-go-verification/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/x509"
@@ -208,7 +209,7 @@ func run() error {
 		fmt.Fprintf(os.Stderr, "No artifact provided, skipping artifact verification. This is unsafe!\n")
 	}
 
-	res, err := sev.Verify(b, verify.NewPolicy(artifactPolicy, identityPolicies...))
+	res, err := sev.Verify(context.TODO(), b, verify.NewPolicy(artifactPolicy, identityPolicies...))
 	if err != nil {
 		return err
 	}

--- a/pkg/sign/signer.go
+++ b/pkg/sign/signer.go
@@ -159,7 +159,7 @@ func Bundle(content Content, keypair Keypair, opts BundleOptions) (*protobundle.
 		}
 
 		policy := verify.NewPolicy(artifactOpts, verify.WithoutIdentitiesUnsafe())
-		_, err = sev.Verify(protobundle, policy)
+		_, err = sev.Verify(opts.Context, protobundle, policy)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/verify/fuzz_test.go
+++ b/pkg/verify/fuzz_test.go
@@ -16,6 +16,7 @@ package verify_test
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"testing"
 
@@ -109,6 +110,7 @@ Tests Verify with an entity that contains a randomized
 email and statement and a randomized root
 */
 func FuzzSignedEntityVerifier(f *testing.F) {
+	ctx := context.TODO()
 	f.Fuzz(func(t *testing.T, trustedrootJSON,
 		bundleBytes []byte) {
 		trustedRoot, err := root.NewTrustedRootFromJSON(trustedrootJSON)
@@ -131,7 +133,7 @@ func FuzzSignedEntityVerifier(f *testing.F) {
 			t.Fatal(err)
 		}
 		//nolint:errcheck
-		v.Verify(entity, FuzzSkipArtifactAndIdentitiesPolicy)
+		v.Verify(ctx, entity, FuzzSkipArtifactAndIdentitiesPolicy)
 	})
 }
 

--- a/pkg/verify/signed_entity.go
+++ b/pkg/verify/signed_entity.go
@@ -15,6 +15,7 @@
 package verify
 
 import (
+	"context"
 	"crypto/x509"
 	"encoding/asn1"
 	"encoding/json"
@@ -567,7 +568,7 @@ func WithArtifactDigests(digests []ArtifactDigest) ArtifactPolicyOption {
 //     expected value
 //   - (if the signed entity has a dsse envelope) verify that the envelope's
 //     statement's subject matches the artifact being verified
-func (v *SignedEntityVerifier) Verify(entity SignedEntity, pb PolicyBuilder) (*VerificationResult, error) {
+func (v *SignedEntityVerifier) Verify(_ context.Context, entity SignedEntity, pb PolicyBuilder) (*VerificationResult, error) {
 	policy, err := pb.BuildConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to build policy: %w", err)

--- a/pkg/verify/signed_entity_test.go
+++ b/pkg/verify/signed_entity_test.go
@@ -15,6 +15,7 @@
 package verify_test
 
 import (
+	"context"
 	"crypto/x509"
 	"errors"
 	"strings"
@@ -81,13 +82,14 @@ func TestSignedEntityVerifierInitRequiresTimestamp(t *testing.T) {
 // - zero tsa entries
 
 func TestEntitySignedByPublicGoodWithTlogVerifiesSuccessfully(t *testing.T) {
+	ctx := context.TODO()
 	tr := data.TrustedRoot(t, "public-good.json")
 	entity := data.Bundle(t, "sigstore.js@2.0.0-provenance.sigstore.json")
 
 	v, err := verify.NewSignedEntityVerifier(tr, verify.WithTransparencyLog(1), verify.WithObserverTimestamps(1))
 	assert.NoError(t, err)
 
-	res, err := v.Verify(entity, SkipArtifactAndIdentitiesPolicy)
+	res, err := v.Verify(ctx, entity, SkipArtifactAndIdentitiesPolicy)
 	assert.NoError(t, err)
 	assert.NotNil(t, res)
 
@@ -102,7 +104,7 @@ func TestEntitySignedByPublicGoodWithTlogVerifiesSuccessfully(t *testing.T) {
 	// verifies with integrated timestamp threshold too
 	v, err = verify.NewSignedEntityVerifier(tr, verify.WithTransparencyLog(1), verify.WithIntegratedTimestamps(1))
 	assert.NoError(t, err)
-	res, err = v.Verify(entity, SkipArtifactAndIdentitiesPolicy)
+	res, err = v.Verify(ctx, entity, SkipArtifactAndIdentitiesPolicy)
 	assert.NoError(t, err)
 	assert.NotNil(t, res)
 }
@@ -114,7 +116,7 @@ func TestEntitySignedByPublicGoodWithoutTimestampsVerifiesSuccessfully(t *testin
 	v, err := verify.NewSignedEntityVerifier(tr, verify.WithTransparencyLog(1), verify.WithIntegratedTimestamps(1))
 	assert.NoError(t, err)
 
-	res, err := v.Verify(entity, SkipArtifactAndIdentitiesPolicy)
+	res, err := v.Verify(context.TODO(), entity, SkipArtifactAndIdentitiesPolicy)
 	assert.NoError(t, err)
 	assert.NotNil(t, res)
 }
@@ -126,7 +128,7 @@ func TestEntitySignedByPublicGoodWithHighTlogThresholdFails(t *testing.T) {
 	v, err := verify.NewSignedEntityVerifier(tr, verify.WithTransparencyLog(2), verify.WithObserverTimestamps(1))
 	assert.NoError(t, err)
 
-	res, err := v.Verify(entity, SkipArtifactAndIdentitiesPolicy)
+	res, err := v.Verify(context.TODO(), entity, SkipArtifactAndIdentitiesPolicy)
 	assert.Error(t, err)
 	assert.Nil(t, res)
 	if !strings.Contains(err.Error(), "not enough verified log entries from transparency log") {
@@ -135,13 +137,14 @@ func TestEntitySignedByPublicGoodWithHighTlogThresholdFails(t *testing.T) {
 }
 
 func TestEntitySignedByPublicGoodWithoutVerifyingLogEntryFails(t *testing.T) {
+	ctx := context.TODO()
 	tr := data.TrustedRoot(t, "public-good.json")
 	entity := data.Bundle(t, "sigstore.js@2.0.0-provenance.sigstore.json")
 
 	v, err := verify.NewSignedEntityVerifier(tr, verify.WithObserverTimestamps(1))
 	assert.NoError(t, err)
 
-	res, err := v.Verify(entity, SkipArtifactAndIdentitiesPolicy)
+	res, err := v.Verify(ctx, entity, SkipArtifactAndIdentitiesPolicy)
 	assert.Error(t, err)
 	assert.Nil(t, res)
 	if !strings.Contains(err.Error(), "threshold not met for verified signed & log entry integrated timestamps") {
@@ -151,7 +154,7 @@ func TestEntitySignedByPublicGoodWithoutVerifyingLogEntryFails(t *testing.T) {
 	// also fails trying to use integrated timestamps without verifying the log
 	v, err = verify.NewSignedEntityVerifier(tr, verify.WithIntegratedTimestamps(1))
 	assert.NoError(t, err)
-	res, err = v.Verify(entity, SkipArtifactAndIdentitiesPolicy)
+	res, err = v.Verify(ctx, entity, SkipArtifactAndIdentitiesPolicy)
 	assert.Error(t, err)
 	assert.Nil(t, res)
 	if !strings.Contains(err.Error(), "threshold not met for verified log entry integrated timestamps") {
@@ -166,7 +169,7 @@ func TestEntitySignedByPublicGoodWithHighLogTimestampThresholdFails(t *testing.T
 	v, err := verify.NewSignedEntityVerifier(tr, verify.WithTransparencyLog(1), verify.WithIntegratedTimestamps(2))
 	assert.NoError(t, err)
 
-	res, err := v.Verify(entity, SkipArtifactAndIdentitiesPolicy)
+	res, err := v.Verify(context.TODO(), entity, SkipArtifactAndIdentitiesPolicy)
 	assert.Error(t, err)
 	assert.Nil(t, res)
 	if !strings.Contains(err.Error(), "threshold not met for verified log entry integrated timestamps") {
@@ -181,7 +184,7 @@ func TestEntitySignedByPublicGoodExpectingTSAFails(t *testing.T) {
 	v, err := verify.NewSignedEntityVerifier(tr, verify.WithTransparencyLog(1), verify.WithSignedTimestamps(1))
 	assert.NoError(t, err)
 
-	res, err := v.Verify(entity, SkipArtifactAndIdentitiesPolicy)
+	res, err := v.Verify(context.TODO(), entity, SkipArtifactAndIdentitiesPolicy)
 	assert.Error(t, err)
 	assert.Nil(t, res)
 	if !strings.Contains(err.Error(), "threshold not met for verified signed timestamps") {
@@ -196,7 +199,7 @@ func TestEntitySignedByPublicGoodWithHighObserverTimestampThresholdFails(t *test
 	v, err := verify.NewSignedEntityVerifier(tr, verify.WithTransparencyLog(1), verify.WithObserverTimestamps(2))
 	assert.NoError(t, err)
 
-	res, err := v.Verify(entity, SkipArtifactAndIdentitiesPolicy)
+	res, err := v.Verify(context.TODO(), entity, SkipArtifactAndIdentitiesPolicy)
 	assert.Error(t, err)
 	assert.Nil(t, res)
 	if !strings.Contains(err.Error(), "threshold not met for verified signed & log entry integrated timestamps") {
@@ -205,6 +208,7 @@ func TestEntitySignedByPublicGoodWithHighObserverTimestampThresholdFails(t *test
 }
 
 func TestEntityWithOthernameSan(t *testing.T) {
+	ctx := context.TODO()
 	tr := data.TrustedRoot(t, "scaffolding.json")
 	entity := data.Bundle(t, "othername.sigstore.json")
 
@@ -216,7 +220,7 @@ func TestEntityWithOthernameSan(t *testing.T) {
 
 	certID, err := verify.NewShortCertificateIdentity("http://oidc.local:8080", "", "foo!oidc.local", "")
 	assert.NoError(t, err)
-	res, err := v.Verify(entity, verify.NewPolicy(verify.WithArtifactDigest("sha256", digest), verify.WithCertificateIdentity(certID)))
+	res, err := v.Verify(ctx, entity, verify.NewPolicy(verify.WithArtifactDigest("sha256", digest), verify.WithCertificateIdentity(certID)))
 	assert.NoError(t, err)
 	assert.NotNil(t, res)
 
@@ -226,13 +230,14 @@ func TestEntityWithOthernameSan(t *testing.T) {
 	// an email address doesn't verify
 	certID, err = verify.NewShortCertificateIdentity("http://oidc.local:8080", "", "foo@oidc.local", "")
 	assert.NoError(t, err)
-	_, err = v.Verify(entity, verify.NewPolicy(verify.WithArtifactDigest("sha256", digest), verify.WithCertificateIdentity(certID)))
+	_, err = v.Verify(ctx, entity, verify.NewPolicy(verify.WithArtifactDigest("sha256", digest), verify.WithCertificateIdentity(certID)))
 	assert.Error(t, err)
 }
 
 // Now we test policy:
 
 func TestVerifyPolicyOptionErors(t *testing.T) {
+	ctx := context.TODO()
 	tr := data.TrustedRoot(t, "public-good.json")
 	entity := data.Bundle(t, "sigstore.js@2.0.0-provenance.sigstore.json")
 
@@ -292,7 +297,7 @@ func TestVerifyPolicyOptionErors(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// imho good to check that the verify func also fails
-	_, err = verifier.Verify(entity, badArtifactComboPolicy1)
+	_, err = verifier.Verify(ctx, entity, badArtifactComboPolicy1)
 	assert.NotNil(t, err)
 
 	// 2. can't combine several artifact policies
@@ -301,7 +306,7 @@ func TestVerifyPolicyOptionErors(t *testing.T) {
 	_, err = badArtifactComboPolicy2.BuildConfig()
 	assert.NotNil(t, err)
 
-	_, err = verifier.Verify(entity, badArtifactComboPolicy2)
+	_, err = verifier.Verify(ctx, entity, badArtifactComboPolicy2)
 	assert.NotNil(t, err)
 
 	// 3. always have to provide _an_ identity option, even tho it will compile:
@@ -309,7 +314,7 @@ func TestVerifyPolicyOptionErors(t *testing.T) {
 	_, err = badIdentityPolicyOpts.BuildConfig()
 	assert.NotNil(t, err)
 
-	_, err = verifier.Verify(entity, badIdentityPolicyOpts)
+	_, err = verifier.Verify(ctx, entity, badIdentityPolicyOpts)
 	assert.NotNil(t, err)
 
 	// 4. can't combine incompatible identity options
@@ -317,7 +322,7 @@ func TestVerifyPolicyOptionErors(t *testing.T) {
 	_, err = badIdentityPolicyCombo.BuildConfig()
 	assert.NotNil(t, err)
 
-	_, err = verifier.Verify(entity, badIdentityPolicyCombo)
+	_, err = verifier.Verify(ctx, entity, badIdentityPolicyCombo)
 	assert.NotNil(t, err)
 
 	// 5. can't expect certificate and key signature
@@ -327,6 +332,7 @@ func TestVerifyPolicyOptionErors(t *testing.T) {
 }
 
 func TestEntitySignedByPublicGoodWithCertificateIdentityVerifiesSuccessfully(t *testing.T) {
+	ctx := context.TODO()
 	tr := data.TrustedRoot(t, "public-good.json")
 	entity := data.Bundle(t, "sigstore.js@2.0.0-provenance.sigstore.json")
 
@@ -340,7 +346,7 @@ func TestEntitySignedByPublicGoodWithCertificateIdentityVerifiesSuccessfully(t *
 	digest, err := hex.DecodeString("46d4e2f74c4877316640000a6fdf8a8b59f1e0847667973e9859f774dd31b8f1e0937813b777fb66a2ac67d50540fe34640966eee9fc2ccca387082b4c85cd3c")
 	assert.Nil(t, err)
 
-	res, err := verifier.Verify(entity,
+	res, err := verifier.Verify(ctx, entity,
 		verify.NewPolicy(verify.WithArtifactDigest("sha512", digest),
 			verify.WithCertificateIdentity(badCI),
 			verify.WithCertificateIdentity(goodCI)))
@@ -349,7 +355,7 @@ func TestEntitySignedByPublicGoodWithCertificateIdentityVerifiesSuccessfully(t *
 	assert.Equal(t, res.VerifiedIdentity.Issuer.Issuer, verify.ActionsIssuerValue)
 
 	// but if only pass in the bad CI, it will fail:
-	res, err = verifier.Verify(entity,
+	res, err = verifier.Verify(ctx, entity,
 		verify.NewPolicy(
 			verify.WithArtifactDigest("sha512", digest),
 			verify.WithCertificateIdentity(badCI)))
@@ -360,7 +366,7 @@ func TestEntitySignedByPublicGoodWithCertificateIdentityVerifiesSuccessfully(t *
 	badDigest, err := hex.DecodeString("56d4e2f74c4877316640000a6fdf8a8b59f1e0847667973e9859f774dd31b8f1e0937813b777fb66a2ac67d50540fe34640966eee9fc2ccca387082b4c85cd3c")
 	assert.Nil(t, err)
 
-	res, err = verifier.Verify(entity,
+	res, err = verifier.Verify(ctx, entity,
 		verify.NewPolicy(
 			verify.WithArtifactDigest("sha512", badDigest),
 			verify.WithCertificateIdentity(goodCI)))
@@ -384,7 +390,7 @@ func TestThatAllTheJSONKeysStartWithALowerCase(t *testing.T) {
 	verifier, err := verify.NewSignedEntityVerifier(tr, verify.WithTransparencyLog(1), verify.WithObserverTimestamps(1))
 	assert.Nil(t, err)
 
-	res, err := verifier.Verify(entity, SkipArtifactAndIdentitiesPolicy)
+	res, err := verifier.Verify(context.TODO(), entity, SkipArtifactAndIdentitiesPolicy)
 	assert.Nil(t, err)
 
 	rawJSON, err := json.Marshal(res)
@@ -421,7 +427,7 @@ func TestSigstoreBundle2Sig(t *testing.T) {
 	v, err := verify.NewSignedEntityVerifier(tr, verify.WithTransparencyLog(1), verify.WithObserverTimestamps(1))
 	assert.NoError(t, err)
 
-	res, err := v.Verify(entity, SkipArtifactAndIdentitiesPolicy)
+	res, err := v.Verify(context.TODO(), entity, SkipArtifactAndIdentitiesPolicy)
 	assert.True(t, errors.Is(err, verify.ErrDSSEInvalidSignatureCount))
 	assert.Nil(t, res)
 }
@@ -488,7 +494,7 @@ func TestCertificateSignedEntityWithSCTsRequiredVerifiesSuccessfully(t *testing.
 	)
 	assert.NoError(t, err)
 
-	res, err := v.Verify(entity, SkipArtifactAndIdentitiesPolicy)
+	res, err := v.Verify(context.TODO(), entity, SkipArtifactAndIdentitiesPolicy)
 	assert.NoError(t, err)
 	assert.NotNil(t, res)
 	assert.NotNil(t, res.Signature)
@@ -513,7 +519,7 @@ func TestForcedKeySignedEntityWithSCTsRequiredFails(t *testing.T) {
 		forceKey:     true,
 	}
 
-	res, err := v.Verify(keySignedEntity, SkipArtifactAndIdentitiesPolicy)
+	res, err := v.Verify(context.TODO(), keySignedEntity, SkipArtifactAndIdentitiesPolicy)
 	assert.Error(t, err)
 	assert.Nil(t, res)
 	assert.Equal(t,

--- a/test/conformance/main.go
+++ b/test/conformance/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"encoding/hex"
 	"fmt"
 	"log"
@@ -253,7 +254,7 @@ func main() {
 		}
 
 		// Verify bundle
-		_, err = sev.Verify(b, verify.NewPolicy(artifactPolicyOption, identityPolicies...))
+		_, err = sev.Verify(context.TODO(), b, verify.NewPolicy(artifactPolicyOption, identityPolicies...))
 		if err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
See https://github.com/sigstore/sigstore-go/issues/455

Essentially we are trying to finish making major breaking API changes ahead of the v1.0 release, and we think in the future it will be useful to have a context parameter for verifying to either help with cases where verifying makes a network call, or as part of observability telemetry.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
* Adds context parameter to `verify.Verify()`

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
N/A