### PR TITLE
Add context to Rekor interactions in signer

### DIFF
--- a/pkg/sign/certificate_test.go
+++ b/pkg/sign/certificate_test.go
@@ -116,7 +116,7 @@ func Test_GetCertificate(t *testing.T) {
 	opts := &FulcioOptions{Retries: 1, Transport: &mockFulcio{}}
 	fulcio := NewFulcio(opts)
 
-	ctx := context.TODO()
+	ctx := context.Background()
 	keypair, err := NewEphemeralKeypair(nil)
 	assert.Nil(t, err)
 

--- a/pkg/sign/keys_test.go
+++ b/pkg/sign/keys_test.go
@@ -27,7 +27,7 @@ func Test_EphemeralKeypair(t *testing.T) {
 		Hint: []byte("asdf"),
 	}
 
-	ctx := context.TODO()
+	ctx := context.Background()
 	ephemeralKeypair, err := NewEphemeralKeypair(opts)
 	assert.NotNil(t, ephemeralKeypair)
 	assert.Nil(t, err)

--- a/pkg/sign/signer.go
+++ b/pkg/sign/signer.go
@@ -129,7 +129,7 @@ func Bundle(content Content, keypair Keypair, opts BundleOptions) (*protobundle.
 
 	if len(opts.TransparencyLogs) > 0 {
 		for _, transparency := range opts.TransparencyLogs {
-			err = transparency.GetTransparencyLogEntry(verifierPEM, bundle)
+			err = transparency.GetTransparencyLogEntry(opts.Context, verifierPEM, bundle)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sign/signer.go
+++ b/pkg/sign/signer.go
@@ -58,7 +58,7 @@ func Bundle(content Content, keypair Keypair, opts BundleOptions) (*protobundle.
 	}
 
 	if opts.Context == nil {
-		opts.Context = context.TODO()
+		opts.Context = context.Background()
 	}
 
 	bundle := &protobundle.Bundle{MediaType: bundleV03MediaType}

--- a/pkg/sign/timestamping_test.go
+++ b/pkg/sign/timestamping_test.go
@@ -79,7 +79,7 @@ func Test_GetTimestamp(t *testing.T) {
 	// Test happy path
 	opts := &TimestampAuthorityOptions{Retries: 1, Transport: &mockTSAClient{}}
 	tsa := NewTimestampAuthority(opts)
-	ctx := context.TODO()
+	ctx := context.Background()
 	signature := []byte("somestuff")
 	resp, err := tsa.GetTimestamp(ctx, signature)
 	assert.NotNil(t, resp)

--- a/pkg/sign/transparency.go
+++ b/pkg/sign/transparency.go
@@ -45,7 +45,7 @@ type RekorClient interface {
 }
 
 type Transparency interface {
-	GetTransparencyLogEntry([]byte, *protobundle.Bundle) error
+	GetTransparencyLogEntry(context.Context, []byte, *protobundle.Bundle) error
 }
 
 type Rekor struct {
@@ -67,7 +67,7 @@ func NewRekor(opts *RekorOptions) *Rekor {
 	return &Rekor{options: opts}
 }
 
-func (r *Rekor) GetTransparencyLogEntry(pubKeyPEM []byte, b *protobundle.Bundle) error {
+func (r *Rekor) GetTransparencyLogEntry(ctx context.Context, pubKeyPEM []byte, b *protobundle.Bundle) error {
 	artifactProperties := types.ArtifactProperties{
 		PublicKeyBytes: [][]byte{pubKeyPEM},
 	}
@@ -90,7 +90,7 @@ func (r *Rekor) GetTransparencyLogEntry(pubKeyPEM []byte, b *protobundle.Bundle)
 
 		artifactProperties.ArtifactBytes = artifactBytes
 
-		proposedEntry, err = dsseType.CreateProposedEntry(context.TODO(), "", artifactProperties)
+		proposedEntry, err = dsseType.CreateProposedEntry(ctx, "", artifactProperties)
 		if err != nil {
 			return err
 		}
@@ -108,7 +108,7 @@ func (r *Rekor) GetTransparencyLogEntry(pubKeyPEM []byte, b *protobundle.Bundle)
 		artifactProperties.ArtifactHash = rekorUtil.PrefixSHA(hexDigest)
 
 		var err error
-		proposedEntry, err = hashedrekordType.CreateProposedEntry(context.TODO(), "", artifactProperties)
+		proposedEntry, err = hashedrekordType.CreateProposedEntry(ctx, "", artifactProperties)
 		if err != nil {
 			return err
 		}
@@ -124,6 +124,7 @@ func (r *Rekor) GetTransparencyLogEntry(pubKeyPEM []byte, b *protobundle.Bundle)
 		params.SetTimeout(r.options.Timeout)
 	}
 	params.SetProposedEntry(proposedEntry)
+	params.SetContext(ctx)
 
 	if r.options.Client == nil {
 		client, err := client.GetRekorClient(r.options.BaseURL, client.WithUserAgent(util.ConstructUserAgent()), client.WithRetryCount(r.options.Retries))

--- a/pkg/sign/transparency_test.go
+++ b/pkg/sign/transparency_test.go
@@ -124,7 +124,7 @@ func Test_GetTransparencyLogEntry(t *testing.T) {
 	pubkey, err := keypair.GetPublicKeyPem()
 	assert.Nil(t, err)
 
-	err = rekor.GetTransparencyLogEntry([]byte(pubkey), bundle)
+	err = rekor.GetTransparencyLogEntry(ctx, []byte(pubkey), bundle)
 	assert.Nil(t, err)
 	assert.NotNil(t, bundle.VerificationMaterial.TlogEntries)
 }

--- a/pkg/sign/transparency_test.go
+++ b/pkg/sign/transparency_test.go
@@ -60,7 +60,7 @@ func (m *mockRekor) CreateLogEntry(_ *entries.CreateLogEntryParams, _ ...entries
 		return nil, err
 	}
 
-	envelope, err := dsseSigner.SignPayload(context.TODO(), "application/vnd.in-toto+json", envelopeBody)
+	envelope, err := dsseSigner.SignPayload(context.Background(), "application/vnd.in-toto+json", envelopeBody)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ func (m *mockRekor) CreateLogEntry(_ *entries.CreateLogEntryParams, _ ...entries
 }
 
 func Test_GetTransparencyLogEntry(t *testing.T) {
-	ctx := context.TODO()
+	ctx := context.Background()
 
 	// First create a bundle with DSSE content
 	keypair, err := NewEphemeralKeypair(nil)

--- a/pkg/testing/ca/ca.go
+++ b/pkg/testing/ca/ca.go
@@ -184,7 +184,7 @@ func (ca *VirtualSigstore) AttestAtTime(identity, issuer string, envelopeBody []
 		return nil, err
 	}
 
-	envelope, err := dsseSigner.SignPayload(context.TODO(), "application/vnd.in-toto+json", envelopeBody)
+	envelope, err := dsseSigner.SignPayload(context.Background(), "application/vnd.in-toto+json", envelopeBody)
 	if err != nil {
 		return nil, err
 	}
@@ -307,7 +307,7 @@ func (ca *VirtualSigstore) GetInclusionProof(rekorBodyRaw []byte) (*models.Inclu
 	}
 	rootHash := sha256.Sum256(append([]byte("\000"), rekorBodyRaw...))
 	encodedRootHash := hex.EncodeToString(rootHash[:])
-	scBytes, err := util.CreateAndSignCheckpoint(context.TODO(), "rekor.localhost", int64(123), uint64(42), rootHash[:], signer)
+	scBytes, err := util.CreateAndSignCheckpoint(context.Background(), "rekor.localhost", int64(123), uint64(42), rootHash[:], signer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tlog/entry.go
+++ b/pkg/tlog/entry.go
@@ -250,7 +250,7 @@ func (entry *Entry) HasInclusionProof() bool {
 }
 
 func VerifyInclusion(entry *Entry, verifier signature.Verifier) error {
-	err := rekorVerify.VerifyInclusion(context.TODO(), &entry.logEntryAnon)
+	err := rekorVerify.VerifyInclusion(context.Background(), &entry.logEntryAnon)
 	if err != nil {
 		return err
 	}

--- a/pkg/verify/signature.go
+++ b/pkg/verify/signature.go
@@ -136,7 +136,7 @@ func verifyEnvelope(verifier signature.Verifier, envelope EnvelopeContent) error
 		return fmt.Errorf("could not load envelope verifier: %w", err)
 	}
 
-	_, err = envVerifier.Verify(context.TODO(), dsseEnv)
+	_, err = envVerifier.Verify(context.Background(), dsseEnv)
 	if err != nil {
 		return fmt.Errorf("could not verify envelope: %w", err)
 	}


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

- Add context param to `transparency.GetTransparencyLogEntry` and pass where used.
- Pass context to params when calling `CreateLogEntry(params)`
- Rename instances of `context.TODO()` to `context.Background()` -- this is slightly pedantic, but the [intent of `context.TODO`](https://pkg.go.dev/context#TODO) is to annotate code where `it's unclear which Context to use or it is not yet available`; we do not intend to use context in any of these calls, so it's not a "TODO"

Fixes https://github.com/sigstore/sigstore-go/issues/460

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
