### PR TITLE
Fix SigningConfig ValidFor when dates are missing

### DIFF
--- a/pkg/root/signing_config.go
+++ b/pkg/root/signing_config.go
@@ -46,6 +46,16 @@ type ServiceConfiguration struct {
 	Count    uint32
 }
 
+func NewService(s *prototrustroot.Service) Service {
+	validFor := s.GetValidFor()
+	return Service{
+		URL:                 s.GetUrl(),
+		MajorAPIVersion:     s.GetMajorApiVersion(),
+		ValidityPeriodStart: validFor.GetStart().AsTime(),
+		ValidityPeriodEnd:   validFor.GetEnd().AsTime(),
+	}
+}
+
 // SelectService returns which service endpoint should be used based on supported API versions
 // and current time. It will select the first service that matches the criteria. Services should
 // be sorted from newest to oldest validity period start time, to minimize how far clients
@@ -148,13 +158,9 @@ func (sc ServiceConfiguration) ToConfigProtobuf() *prototrustroot.ServiceConfigu
 
 func (sc *SigningConfig) FulcioCertificateAuthorityURLs() []Service {
 	var services []Service
+
 	for _, s := range sc.signingConfig.GetCaUrls() {
-		services = append(services, Service{
-			URL:                 s.GetUrl(),
-			MajorAPIVersion:     s.GetMajorApiVersion(),
-			ValidityPeriodStart: s.GetValidFor().GetStart().AsTime(),
-			ValidityPeriodEnd:   s.GetValidFor().GetEnd().AsTime(),
-		})
+		services = append(services, NewService(s))
 	}
 	return services
 }
@@ -162,12 +168,7 @@ func (sc *SigningConfig) FulcioCertificateAuthorityURLs() []Service {
 func (sc *SigningConfig) OIDCProviderURLs() []Service {
 	var services []Service
 	for _, s := range sc.signingConfig.GetOidcUrls() {
-		services = append(services, Service{
-			URL:                 s.GetUrl(),
-			MajorAPIVersion:     s.GetMajorApiVersion(),
-			ValidityPeriodStart: s.GetValidFor().GetStart().AsTime(),
-			ValidityPeriodEnd:   s.GetValidFor().GetEnd().AsTime(),
-		})
+		services = append(services, NewService(s))
 	}
 	return services
 }
@@ -175,12 +176,7 @@ func (sc *SigningConfig) OIDCProviderURLs() []Service {
 func (sc *SigningConfig) RekorLogURLs() []Service {
 	var services []Service
 	for _, s := range sc.signingConfig.GetRekorTlogUrls() {
-		services = append(services, Service{
-			URL:                 s.GetUrl(),
-			MajorAPIVersion:     s.GetMajorApiVersion(),
-			ValidityPeriodStart: s.GetValidFor().GetStart().AsTime(),
-			ValidityPeriodEnd:   s.GetValidFor().GetEnd().AsTime(),
-		})
+		services = append(services, NewService(s))
 	}
 	return services
 }
@@ -196,12 +192,7 @@ func (sc *SigningConfig) RekorLogURLsConfig() ServiceConfiguration {
 func (sc *SigningConfig) TimestampAuthorityURLs() []Service {
 	var services []Service
 	for _, s := range sc.signingConfig.GetTsaUrls() {
-		services = append(services, Service{
-			URL:                 s.GetUrl(),
-			MajorAPIVersion:     s.GetMajorApiVersion(),
-			ValidityPeriodStart: s.GetValidFor().GetStart().AsTime(),
-			ValidityPeriodEnd:   s.GetValidFor().GetEnd().AsTime(),
-		})
+		services = append(services, NewService(s))
 	}
 	return services
 }
@@ -217,14 +208,7 @@ func (sc *SigningConfig) TimestampAuthorityURLsConfig() ServiceConfiguration {
 func (sc *SigningConfig) WithFulcioCertificateAuthorityURLs(fulcioURLs ...Service) *SigningConfig {
 	var services []*prototrustroot.Service
 	for _, u := range fulcioURLs {
-		services = append(services, &prototrustroot.Service{
-			Url:             u.URL,
-			MajorApiVersion: u.MajorAPIVersion,
-			ValidFor: &v1.TimeRange{
-				Start: timestamppb.New(u.ValidityPeriodStart),
-				End:   timestamppb.New(u.ValidityPeriodEnd),
-			},
-		})
+		services = append(services, u.ToServiceProtobuf())
 	}
 	sc.signingConfig.CaUrls = services
 	return sc

--- a/pkg/root/signing_config.go
+++ b/pkg/root/signing_config.go
@@ -48,11 +48,22 @@ type ServiceConfiguration struct {
 
 func NewService(s *prototrustroot.Service) Service {
 	validFor := s.GetValidFor()
+
+	var start time.Time
+	if validFor.GetStart() != nil {
+		start = validFor.GetStart().AsTime()
+	}
+
+	var end time.Time
+	if validFor.GetEnd() != nil {
+		end = validFor.GetEnd().AsTime()
+	}
+
 	return Service{
 		URL:                 s.GetUrl(),
 		MajorAPIVersion:     s.GetMajorApiVersion(),
-		ValidityPeriodStart: validFor.GetStart().AsTime(),
-		ValidityPeriodEnd:   validFor.GetEnd().AsTime(),
+		ValidityPeriodStart: start,
+		ValidityPeriodEnd:   end,
 	}
 }
 

--- a/pkg/root/signing_config_test.go
+++ b/pkg/root/signing_config_test.go
@@ -686,6 +686,26 @@ func TestSigningConfig_TimestampAuthorityURLs(t *testing.T) {
 			},
 		},
 		{
+			name: "valid, unset end date",
+			signingConfig: &prototrustroot.SigningConfig{
+				TsaUrls: []*prototrustroot.Service{
+					{
+						Url:             "https://timestamp.sigstore.dev",
+						MajorApiVersion: 1,
+						ValidFor:        &v1.TimeRange{Start: timestamppb.New(now), End: nil},
+					},
+				},
+			},
+			want: []Service{
+				{
+					URL:                 "https://timestamp.sigstore.dev",
+					MajorAPIVersion:     1,
+					ValidityPeriodStart: now,
+					ValidityPeriodEnd:   time.Time{},
+				},
+			},
+		},
+		{
 			name: "empty",
 			signingConfig: &prototrustroot.SigningConfig{
 				TsaUrls: []*prototrustroot.Service{},

--- a/pkg/root/trusted_root_test.go
+++ b/pkg/root/trusted_root_test.go
@@ -206,3 +206,17 @@ func TestFromJSONToJSON(t *testing.T) {
 
 	assert.JSONEq(t, trJSONTrimmedTime, string(jsonBytes))
 }
+
+func TestValidityPeriods(t *testing.T) {
+	trustedrootJSON, err := os.ReadFile("../../examples/trusted-root-public-good.json")
+	assert.NoError(t, err)
+
+	trustedRoot, err := NewTrustedRootFromJSON(trustedrootJSON)
+	assert.NoError(t, err)
+
+	// confirm that ValidityPeriodEnd.IsZero() is true for services without end validity date
+	assert.True(t, trustedRoot.ctLogs["dd3d306ac6c7113263191e1c99673702a24a5eb8de3cadff878a72802f29ee8e"].ValidityPeriodEnd.IsZero())
+	assert.True(t, trustedRoot.certificateAuthorities[1].(*FulcioCertificateAuthority).ValidityPeriodEnd.IsZero())
+	assert.True(t, trustedRoot.rekorLogs["c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d"].ValidityPeriodEnd.IsZero())
+	assert.True(t, trustedRoot.timestampingAuthorities[0].(*SigstoreTimestampingAuthority).ValidityPeriodEnd.IsZero())
+}


### PR DESCRIPTION
Fixes #464: Make sure we handle missing dates in ValidFor protobuf as a special case. The time that we deserialize in that case needs to be 01-01-01 and not the protobuf default 1970-01-01 because we want to be able to check for it with `Time.IsZero()`