### PR TITLE
correct error on unsupported TrustedRoot media type

### DIFF
--- a/pkg/root/trusted_root.go
+++ b/pkg/root/trusted_root.go
@@ -367,6 +367,7 @@ func NewTrustedRootProtobuf(rootJSON []byte) (*prototrustroot.TrustedRoot, error
 // NewTrustedRoot initializes a TrustedRoot object from a mediaType string, list of Fulcio
 // certificate authorities, list of timestamp authorities and maps of ctlogs and rekor
 // transparency log instances.
+// mediaType must be TrustedRootMediaType01 ("application/vnd.dev.sigstore.trustedroot+json;version=0.1").
 func NewTrustedRoot(mediaType string,
 	certificateAuthorities []CertificateAuthority,
 	certificateTransparencyLogs map[string]*TransparencyLog,
@@ -374,7 +375,7 @@ func NewTrustedRoot(mediaType string,
 	transparencyLogs map[string]*TransparencyLog) (*TrustedRoot, error) {
 	// document that we assume 1 cert chain per target and with certs already ordered from leaf to root
 	if mediaType != TrustedRootMediaType01 {
-		return nil, fmt.Errorf("unsupported TrustedRoot media type: %s", TrustedRootMediaType01)
+		return nil, fmt.Errorf("unsupported TrustedRoot media type: %s, must be %s", mediaType, TrustedRootMediaType01)
 	}
 	tr := &TrustedRoot{
 		certificateAuthorities:  certificateAuthorities,

--- a/pkg/root/trusted_root_test.go
+++ b/pkg/root/trusted_root_test.go
@@ -73,6 +73,30 @@ func (*nonExpiringVerifier) ValidAtTime(_ time.Time) bool {
 	return true
 }
 
+func TestNewTrustedRoot(t *testing.T) {
+	trustedrootJSON, err := os.ReadFile("../../examples/trusted-root-public-good.json")
+	assert.NoError(t, err)
+
+	tr, err := NewTrustedRootFromJSON(trustedrootJSON)
+	assert.NoError(t, err)
+
+	tr2, err := NewTrustedRoot(
+		TrustedRootMediaType01,
+		tr.certificateAuthorities,
+		tr.ctLogs,
+		tr.timestampingAuthorities,
+		tr.rekorLogs,
+	)
+	assert.NoError(t, err)
+	// tr and tr2 are not "fully" equal because of the trustedRoot field
+	assert.Equal(t, tr.trustedRoot.MediaType, TrustedRootMediaType01)
+	assert.Equal(t, tr.BaseTrustedMaterial, tr2.BaseTrustedMaterial)
+	assert.Equal(t, tr.certificateAuthorities, tr2.certificateAuthorities)
+	assert.Equal(t, tr.ctLogs, tr2.ctLogs)
+	assert.Equal(t, tr.timestampingAuthorities, tr2.timestampingAuthorities)
+	assert.Equal(t, tr.rekorLogs, tr2.rekorLogs)
+}
+
 func TestTrustedMaterialCollectionECDSA(t *testing.T) {
 	trustedrootJSON, err := os.ReadFile("../../examples/trusted-root-public-good.json")
 	assert.NoError(t, err)


### PR DESCRIPTION
#### Summary
I believe the error on an unsupported media type is wrong - it currently sounds as if `TrustedRootMediaType01` were the unsupported one! Corrected it to print both the given and expected media types, added a basic unit test for `NewTrustedRoot`.

#### Release Note
NONE

#### Documentation
N/A
