### PR TITLE
Disable TUF timestamping when TUF cache disabled

### DIFF
--- a/pkg/tuf/client.go
+++ b/pkg/tuf/client.go
@@ -150,7 +150,10 @@ func (c *Client) Refresh() error {
 	if err != nil {
 		return fmt.Errorf("tuf refresh failed: %w", err)
 	}
-
+	// If cache is disabled, we don't need to persist the last timestamp
+	if c.cfg.DisableLocalCache {
+		return nil
+	}
 	// Update config with last update
 	cfg, err := LoadConfig(c.configPath())
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Cody Soyland <codysoyland@github.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

I noticed that the TUF client will write timestamp files into CWD when the TUF cache is disabled. The intent of these files is to track the last TUF update time, but when the cache is disabled, these files should not be persisted. This PR modifies the logic so the last updated time is not persisted when the cache is disabled.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
