### PR TITLE
Prevent duplicate timestamps from same TSA

### DIFF
--- a/pkg/testing/ca/ca.go
+++ b/pkg/testing/ca/ca.go
@@ -69,7 +69,10 @@ type VirtualSigstore struct {
 }
 
 func NewVirtualSigstoreWithSigningAlg(signingKeyDetails v1.PublicKeyDetails) (*VirtualSigstore, error) {
-	ss := &VirtualSigstore{fulcioCA: &root.FulcioCertificateAuthority{}, tsaCA: &root.SigstoreTimestampingAuthority{}}
+	ss := &VirtualSigstore{
+		fulcioCA: &root.FulcioCertificateAuthority{URI: "https://virtual.fulcio.sigstore.dev"},
+		tsaCA:    &root.SigstoreTimestampingAuthority{URI: "https://virtual.tsa.sigstore.dev"},
+	}
 
 	rootCert, rootKey, err := GenerateRootCa()
 	if err != nil {

--- a/pkg/verify/tsa_test.go
+++ b/pkg/verify/tsa_test.go
@@ -112,8 +112,8 @@ func TestDuplicateTimestamps(t *testing.T) {
 	entity, err := virtualSigstore.Attest("foo@example.com", "issuer", []byte("statement"))
 	assert.NoError(t, err)
 
-	_, err = verify.VerifyTimestampAuthorityWithThreshold(&dupTimestampEntity{entity}, virtualSigstore, 1)
-	assert.ErrorContains(t, err, "duplicate timestamps found")
+	_, err = verify.VerifyTimestampAuthority(&dupTimestampEntity{entity}, virtualSigstore)
+	assert.ErrorContains(t, err, "duplicate timestamps from the same authority, ignoring https://virtual.tsa.sigstore.dev")
 }
 
 type badTSASignatureEntity struct {


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

This modifies the duplicate detection so it does not compare the bytes of the timestamp, but instead the authority.

This prevents a single compromised TSA from being used to meet a threshold of greater than 1 by duplicating timestamps.

Fixes https://github.com/sigstore/sigstore-go/issues/471

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
