### PR TITLE
Add verification errors to output of VerifyTimestampAuthority

### DIFF
--- a/pkg/verify/signed_entity.go
+++ b/pkg/verify/signed_entity.go
@@ -814,16 +814,16 @@ func (v *SignedEntityVerifier) VerifyObserverTimestamps(entity SignedEntity, log
 	}
 
 	if v.config.requireObserverTimestamps {
-		verifiedSignedTimestamps, err := VerifyTimestampAuthority(entity, v.trustedMaterial)
+		verifiedSignedTimestamps, verificationErrors, err := VerifyTimestampAuthority(entity, v.trustedMaterial)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to verify signed timestamps: %w", err)
 		}
 
 		// check threshold for both RFC3161 and log timestamps
 		tsCount := len(verifiedSignedTimestamps) + len(logTimestamps)
 		if tsCount < v.config.observerTimestampThreshold {
-			return nil, fmt.Errorf("threshold not met for verified signed & log entry integrated timestamps: %d < %d",
-				tsCount, v.config.observerTimestampThreshold)
+			return nil, fmt.Errorf("threshold not met for verified signed & log entry integrated timestamps: %d < %d; error: %w",
+				tsCount, v.config.observerTimestampThreshold, errors.Join(verificationErrors...))
 		}
 
 		// append all timestamps

--- a/pkg/verify/tsa.go
+++ b/pkg/verify/tsa.go
@@ -25,39 +25,40 @@ const maxAllowedTimestamps = 32
 
 // VerifyTimestampAuthority verifies that the given entity has been timestamped
 // by a trusted timestamp authority and that the timestamp is valid.
-func VerifyTimestampAuthority(entity SignedEntity, trustedMaterial root.TrustedMaterial) ([]*root.Timestamp, error) { //nolint:revive
+func VerifyTimestampAuthority(entity SignedEntity, trustedMaterial root.TrustedMaterial) ([]*root.Timestamp, []error, error) { //nolint:revive
 	signedTimestamps, err := entity.Timestamps()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// limit the number of timestamps to prevent DoS
 	if len(signedTimestamps) > maxAllowedTimestamps {
-		return nil, fmt.Errorf("too many signed timestamps: %d > %d", len(signedTimestamps), maxAllowedTimestamps)
+		return nil, nil, fmt.Errorf("too many signed timestamps: %d > %d", len(signedTimestamps), maxAllowedTimestamps)
 	}
 	sigContent, err := entity.SignatureContent()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	signatureBytes := sigContent.Signature()
 
 	verifiedTimestamps := []*root.Timestamp{}
+	var verificationErrors []error
 	for _, timestamp := range signedTimestamps {
 		verifiedSignedTimestamp, err := verifySignedTimestamp(timestamp, signatureBytes, trustedMaterial)
 		if err != nil {
+			verificationErrors = append(verificationErrors, err)
 			continue
 		}
 		if isDuplicateTSA(verifiedTimestamps, verifiedSignedTimestamp) {
-			// TODO: add below error to `errs` when #325 is merged, and continue
-			// (https://github.com/sigstore/sigstore-go/issues/325)
-			return verifiedTimestamps, fmt.Errorf("duplicate timestamps from the same authority, ignoring %s", verifiedSignedTimestamp.URI)
+			verificationErrors = append(verificationErrors, fmt.Errorf("duplicate timestamps from the same authority, ignoring %s", verifiedSignedTimestamp.URI))
+			continue
 		}
 
 		verifiedTimestamps = append(verifiedTimestamps, verifiedSignedTimestamp)
 	}
 
-	return verifiedTimestamps, nil
+	return verifiedTimestamps, verificationErrors, nil
 }
 
 // isDuplicateTSA checks if the given verified signed timestamp is a duplicate
@@ -79,12 +80,12 @@ func isDuplicateTSA(verifiedTimestamps []*root.Timestamp, verifiedSignedTimestam
 // The threshold parameter is the number of unique timestamps that must be
 // verified.
 func VerifyTimestampAuthorityWithThreshold(entity SignedEntity, trustedMaterial root.TrustedMaterial, threshold int) ([]*root.Timestamp, error) { //nolint:revive
-	verifiedTimestamps, err := VerifyTimestampAuthority(entity, trustedMaterial)
+	verifiedTimestamps, verificationErrors, err := VerifyTimestampAuthority(entity, trustedMaterial)
 	if err != nil {
 		return nil, err
 	}
 	if len(verifiedTimestamps) < threshold {
-		return nil, fmt.Errorf("threshold not met for verified signed timestamps: %d < %d", len(verifiedTimestamps), threshold)
+		return nil, fmt.Errorf("threshold not met for verified signed timestamps: %d < %d; error: %w", len(verifiedTimestamps), threshold, errors.Join(verificationErrors...))
 	}
 	return verifiedTimestamps, nil
 }
@@ -92,13 +93,16 @@ func VerifyTimestampAuthorityWithThreshold(entity SignedEntity, trustedMaterial 
 func verifySignedTimestamp(signedTimestamp []byte, signatureBytes []byte, trustedMaterial root.TrustedMaterial) (*root.Timestamp, error) {
 	timestampAuthorities := trustedMaterial.TimestampingAuthorities()
 
+	var errs []error
+
 	// Iterate through TSA certificate authorities to find one that verifies
 	for _, tsa := range timestampAuthorities {
 		ts, err := tsa.Verify(signedTimestamp, signatureBytes)
 		if err == nil {
 			return ts, nil
 		}
+		errs = append(errs, err)
 	}
 
-	return nil, errors.New("unable to verify signed timestamps")
+	return nil, fmt.Errorf("unable to verify signed timestamps: %w", errors.Join(errs...))
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

This is an alternative to https://github.com/sigstore/sigstore-go/pull/325 which modifies the return value of `VerifyTimestampAuthority` to include verification errors separately from non-verification errors.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
