### PR TITLE
Update theupdateframework/go-tuf to v2.1.0 and copy in unexported repo type from `theupdateframework/go-tuf/examples/repository` directory

### DIFF
--- a/examples/oci-image-verification/go.mod
+++ b/examples/oci-image-verification/go.mod
@@ -16,6 +16,7 @@ require (
 require (
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
+	github.com/cenkalti/backoff/v5 v5.0.2 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.16.3 // indirect
 	github.com/cyberphone/json-canonicalization v0.0.0-20220623050100-57a0ce2678a7 // indirect
 	github.com/digitorus/pkcs7 v0.0.0-20230818184609-3a137a874352 // indirect
@@ -72,7 +73,7 @@ require (
 	github.com/spf13/viper v1.20.1 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/theupdateframework/go-tuf v0.7.0 // indirect
-	github.com/theupdateframework/go-tuf/v2 v2.0.2 // indirect
+	github.com/theupdateframework/go-tuf/v2 v2.1.0 // indirect
 	github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399 // indirect
 	github.com/transparency-dev/merkle v0.0.2 // indirect
 	github.com/vbatts/tar-split v0.11.6 // indirect

--- a/examples/oci-image-verification/go.sum
+++ b/examples/oci-image-verification/go.sum
@@ -68,6 +68,8 @@ github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdn
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
+github.com/cenkalti/backoff/v5 v5.0.2 h1:rIfFVxEf1QsI7E1ZHfp/B4DF/6QBAUhmgkxc0H7Zss8=
+github.com/cenkalti/backoff/v5 v5.0.2/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb h1:EDmT6Q9Zs+SbUoc7Ik9EfrFqcylYqgPZ9ANSbTAntnE=
@@ -310,8 +312,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/theupdateframework/go-tuf v0.7.0 h1:CqbQFrWo1ae3/I0UCblSbczevCCbS31Qvs5LdxRWqRI=
 github.com/theupdateframework/go-tuf v0.7.0/go.mod h1:uEB7WSY+7ZIugK6R1hiBMBjQftaFzn7ZCDJcp1tCUug=
-github.com/theupdateframework/go-tuf/v2 v2.0.2 h1:PyNnjV9BJNzN1ZE6BcWK+5JbF+if370jjzO84SS+Ebo=
-github.com/theupdateframework/go-tuf/v2 v2.0.2/go.mod h1:baB22nBHeHBCeuGZcIlctNq4P61PcOdyARlplg5xmLA=
+github.com/theupdateframework/go-tuf/v2 v2.1.0 h1:NlcIR4rftUDILPMFS3TUPvB7BPw/L8E53fNlSPoT9MY=
+github.com/theupdateframework/go-tuf/v2 v2.1.0/go.mod h1:V675cQGhZONR0OGQ8r1feO0uwtsTBYPDWHzAAPn5rjE=
 github.com/tink-crypto/tink-go-awskms/v2 v2.1.0 h1:N9UxlsOzu5mttdjhxkDLbzwtEecuXmlxZVo/ds7JKJI=
 github.com/tink-crypto/tink-go-awskms/v2 v2.1.0/go.mod h1:PxSp9GlOkKL9rlybW804uspnHuO9nbD98V/fDX4uSis=
 github.com/tink-crypto/tink-go-gcpkms/v2 v2.2.0 h1:3B9i6XBXNTRspfkTC0asN5W0K6GhOSgcujNiECNRNb0=

--- a/examples/sigstore-go-signing/main.go
+++ b/examples/sigstore-go-signing/main.go
@@ -104,13 +104,13 @@ func main() {
 		}
 	} else if signingconfigPath == "" {
 		// Get staging trusted_root.json by default
-		fetcher := fetcher.DefaultFetcher{}
+		fetcher := fetcher.NewDefaultFetcher()
 		fetcher.SetHTTPUserAgent(util.ConstructUserAgent())
 
 		tufOptions := &tuf.Options{
 			Root:              tuf.StagingRoot(),
 			RepositoryBaseURL: tuf.StagingMirror,
-			Fetcher:           &fetcher,
+			Fetcher:           fetcher,
 		}
 		tufClient, err := tuf.New(tufOptions)
 		if err != nil {

--- a/examples/sigstore-go-verification/main.go
+++ b/examples/sigstore-go-verification/main.go
@@ -128,9 +128,9 @@ func run() error {
 	if *tufRootURL != "" {
 		opts := tuf.DefaultOptions()
 		opts.RepositoryBaseURL = *tufRootURL
-		fetcher := fetcher.DefaultFetcher{}
+		fetcher := fetcher.NewDefaultFetcher()
 		fetcher.SetHTTPUserAgent(util.ConstructUserAgent())
-		opts.Fetcher = &fetcher
+		opts.Fetcher = fetcher
 
 		// Load the tuf root.json if provided, if not use public good
 		if *tufTrustedRoot != "" {

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/sigstore/sigstore v1.9.4
 	github.com/sigstore/timestamp-authority v1.2.6
 	github.com/stretchr/testify v1.10.0
-	github.com/theupdateframework/go-tuf/v2 v2.0.2
+	github.com/theupdateframework/go-tuf/v2 v2.1.0
 	golang.org/x/crypto v0.37.0
 	golang.org/x/mod v0.24.0
 	google.golang.org/protobuf v1.36.6
@@ -29,6 +29,7 @@ require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
+	github.com/cenkalti/backoff/v5 v5.0.2 // indirect
 	github.com/coreos/go-oidc/v3 v3.14.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/digitorus/pkcs7 v0.0.0-20230818184609-3a137a874352 // indirect

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdn
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
+github.com/cenkalti/backoff/v5 v5.0.2 h1:rIfFVxEf1QsI7E1ZHfp/B4DF/6QBAUhmgkxc0H7Zss8=
+github.com/cenkalti/backoff/v5 v5.0.2/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb h1:EDmT6Q9Zs+SbUoc7Ik9EfrFqcylYqgPZ9ANSbTAntnE=
@@ -315,8 +317,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/theupdateframework/go-tuf v0.7.0 h1:CqbQFrWo1ae3/I0UCblSbczevCCbS31Qvs5LdxRWqRI=
 github.com/theupdateframework/go-tuf v0.7.0/go.mod h1:uEB7WSY+7ZIugK6R1hiBMBjQftaFzn7ZCDJcp1tCUug=
-github.com/theupdateframework/go-tuf/v2 v2.0.2 h1:PyNnjV9BJNzN1ZE6BcWK+5JbF+if370jjzO84SS+Ebo=
-github.com/theupdateframework/go-tuf/v2 v2.0.2/go.mod h1:baB22nBHeHBCeuGZcIlctNq4P61PcOdyARlplg5xmLA=
+github.com/theupdateframework/go-tuf/v2 v2.1.0 h1:NlcIR4rftUDILPMFS3TUPvB7BPw/L8E53fNlSPoT9MY=
+github.com/theupdateframework/go-tuf/v2 v2.1.0/go.mod h1:V675cQGhZONR0OGQ8r1feO0uwtsTBYPDWHzAAPn5rjE=
 github.com/tink-crypto/tink-go-awskms/v2 v2.1.0 h1:N9UxlsOzu5mttdjhxkDLbzwtEecuXmlxZVo/ds7JKJI=
 github.com/tink-crypto/tink-go-awskms/v2 v2.1.0/go.mod h1:PxSp9GlOkKL9rlybW804uspnHuO9nbD98V/fDX4uSis=
 github.com/tink-crypto/tink-go-gcpkms/v2 v2.2.0 h1:3B9i6XBXNTRspfkTC0asN5W0K6GhOSgcujNiECNRNb0=

--- a/pkg/tuf/client.go
+++ b/pkg/tuf/client.go
@@ -60,9 +60,9 @@ func New(opts *Options) (*Client, error) {
 	if opts.Fetcher != nil {
 		c.cfg.Fetcher = opts.Fetcher
 	} else {
-		fetcher := fetcher.DefaultFetcher{}
+		fetcher := fetcher.NewDefaultFetcher()
 		fetcher.SetHTTPUserAgent(util.ConstructUserAgent())
-		c.cfg.Fetcher = &fetcher
+		c.cfg.Fetcher = fetcher
 	}
 
 	// Upon client creation, we may not perform a full TUF update,

--- a/pkg/tuf/client_test.go
+++ b/pkg/tuf/client_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/stretchr/testify/assert"
 	"github.com/theupdateframework/go-tuf/v2/metadata"
-	"github.com/theupdateframework/go-tuf/v2/metadata/repository"
+	"github.com/theupdateframework/go-tuf/v2/examples/repository"
 	"golang.org/x/crypto/ed25519"
 )
 
@@ -247,7 +247,7 @@ func TestExpiredTimestamp(t *testing.T) {
 }
 
 // repo represents repositoryType from
-// github.com/theupdateframework/go-tuf/v2/metadata/repository, which is
+// github.com/theupdateframework/go-tuf/v2/examples/repository, which is
 // unexported.
 type repo interface {
 	Root() *metadata.Metadata[metadata.RootType]

--- a/pkg/tuf/client_test.go
+++ b/pkg/tuf/client_test.go
@@ -296,7 +296,7 @@ func (r *repo) SetTargets(name string, meta *metadata.Metadata[metadata.TargetsT
 }
 
 // New creates an empty repository instance
-func NewRepo() repo {
+func newRepo() repo {
 	return repo{
 		targets: map[string]*metadata.Metadata[metadata.TargetsType]{},
 	}
@@ -318,7 +318,7 @@ func newTestRepo(t *testing.T) *testRepo {
 	var err error
 	r := &testRepo{
 		keys:  make(map[string]ed25519.PrivateKey),
-		roles: NewRepo(),
+		roles: newRepo(),
 		t:     t,
 	}
 	tomorrow := time.Now().AddDate(0, 0, 1).UTC()

--- a/pkg/tuf/client_test.go
+++ b/pkg/tuf/client_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/stretchr/testify/assert"
 	"github.com/theupdateframework/go-tuf/v2/metadata"
-	"github.com/theupdateframework/go-tuf/v2/examples/repository"
 	"golang.org/x/crypto/ed25519"
 )
 
@@ -249,15 +248,58 @@ func TestExpiredTimestamp(t *testing.T) {
 // repo represents repositoryType from
 // github.com/theupdateframework/go-tuf/v2/examples/repository, which is
 // unexported.
-type repo interface {
-	Root() *metadata.Metadata[metadata.RootType]
-	SetRoot(meta *metadata.Metadata[metadata.RootType])
-	Snapshot() *metadata.Metadata[metadata.SnapshotType]
-	SetSnapshot(meta *metadata.Metadata[metadata.SnapshotType])
-	Timestamp() *metadata.Metadata[metadata.TimestampType]
-	SetTimestamp(meta *metadata.Metadata[metadata.TimestampType])
-	Targets(name string) *metadata.Metadata[metadata.TargetsType]
-	SetTargets(name string, meta *metadata.Metadata[metadata.TargetsType])
+type repo struct {
+	root      *metadata.Metadata[metadata.RootType]
+	snapshot  *metadata.Metadata[metadata.SnapshotType]
+	timestamp *metadata.Metadata[metadata.TimestampType]
+	targets   map[string]*metadata.Metadata[metadata.TargetsType]
+}
+
+// Root returns metadata of type Root
+func (r *repo) Root() *metadata.Metadata[metadata.RootType] {
+	return r.root
+}
+
+// SetRoot sets metadata of type Root
+func (r *repo) SetRoot(meta *metadata.Metadata[metadata.RootType]) {
+	r.root = meta
+}
+
+// Snapshot returns metadata of type Snapshot
+func (r *repo) Snapshot() *metadata.Metadata[metadata.SnapshotType] {
+	return r.snapshot
+}
+
+// SetSnapshot sets metadata of type Snapshot
+func (r *repo) SetSnapshot(meta *metadata.Metadata[metadata.SnapshotType]) {
+	r.snapshot = meta
+}
+
+// Timestamp returns metadata of type Timestamp
+func (r *repo) Timestamp() *metadata.Metadata[metadata.TimestampType] {
+	return r.timestamp
+}
+
+// SetTimestamp sets metadata of type Timestamp
+func (r *repo) SetTimestamp(meta *metadata.Metadata[metadata.TimestampType]) {
+	r.timestamp = meta
+}
+
+// Targets returns metadata of type Targets
+func (r *repo) Targets(name string) *metadata.Metadata[metadata.TargetsType] {
+	return r.targets[name]
+}
+
+// SetTargets sets metadata of type Targets
+func (r *repo) SetTargets(name string, meta *metadata.Metadata[metadata.TargetsType]) {
+	r.targets[name] = meta
+}
+
+// New creates an empty repository instance
+func NewRepo() repo {
+	return repo{
+		targets: map[string]*metadata.Metadata[metadata.TargetsType]{},
+	}
 }
 
 // testRepo is a basic implementation of a TUF repository for testing purposes.
@@ -276,7 +318,7 @@ func newTestRepo(t *testing.T) *testRepo {
 	var err error
 	r := &testRepo{
 		keys:  make(map[string]ed25519.PrivateKey),
-		roles: repository.New(),
+		roles: NewRepo(),
 		t:     t,
 	}
 	tomorrow := time.Now().AddDate(0, 0, 1).UTC()

--- a/pkg/tuf/client_test.go
+++ b/pkg/tuf/client_test.go
@@ -246,7 +246,7 @@ func TestExpiredTimestamp(t *testing.T) {
 }
 
 // repo represents repositoryType from
-// github.com/theupdateframework/go-tuf/v2/examples/repository, which is
+// github.com/theupdateframework/go-tuf/examples/repository, which is
 // unexported.
 type repo struct {
 	root      *metadata.Metadata[metadata.RootType]

--- a/pkg/tuf/options.go
+++ b/pkg/tuf/options.go
@@ -130,6 +130,7 @@ func DefaultOptions() *Options {
 	}
 	opts.CachePath = filepath.Join(home, ".sigstore", "root")
 	opts.RepositoryBaseURL = DefaultMirror
+	opts.Fetcher = fetcher.NewDefaultFetcher()
 
 	return &opts
 }

--- a/test/conformance/main.go
+++ b/test/conformance/main.go
@@ -55,9 +55,9 @@ func getTrustedRoot(staging bool) root.TrustedMaterial {
 		trustedRootJSON, err = os.ReadFile(*trustedRootPath)
 	} else {
 		opts := tuf.DefaultOptions()
-		fetcher := fetcher.DefaultFetcher{}
+		fetcher := fetcher.NewDefaultFetcher()
 		fetcher.SetHTTPUserAgent(util.ConstructUserAgent())
-		opts.Fetcher = &fetcher
+		opts.Fetcher = fetcher
 
 		if staging {
 			opts.Root = tuf.StagingRoot()


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

While working on a project, I imported both theupdateframework/go-tuf and sigstore/sigstore-go. I encountered the error:
```
go: finding module for package github.com/theupdateframework/go-tuf/v2/metadata/repository
go: github.com/cli/cli/v2/pkg/cmd/attestation/trustedroot imports
	github.com/sigstore/sigstore-go/pkg/tuf tested by
	github.com/sigstore/sigstore-go/pkg/tuf.test imports
	github.com/theupdateframework/go-tuf/v2/metadata/repository: module github.com/theupdateframework/go-tuf/v2@latest found (v2.1.0), but does not contain package github.com/theupdateframework/go-tuf/v2/metadata/repository
```

Because the [struct `Type`](https://github.com/theupdateframework/go-tuf/blob/master/examples/repository/repository/repository.go#L25) is part of an unexported package, we cannot import the `exmaples/repository` package. Instead I just replaced the unexported `repo` interface with the copied in the `Type` struct.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
