### PR TITLE
Use repository.Type from go-tuf in tests

### DIFF
--- a/pkg/tuf/client_test.go
+++ b/pkg/tuf/client_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/stretchr/testify/assert"
+	"github.com/theupdateframework/go-tuf/v2/examples/repository/repository"
 	"github.com/theupdateframework/go-tuf/v2/metadata"
 	"golang.org/x/crypto/ed25519"
 )
@@ -245,63 +246,6 @@ func TestExpiredTimestamp(t *testing.T) {
 	assert.Equal(t, target, []byte("foo version 2"))
 }
 
-// repo represents repositoryType from
-// github.com/theupdateframework/go-tuf/examples/repository, which is
-// unexported.
-type repo struct {
-	root      *metadata.Metadata[metadata.RootType]
-	snapshot  *metadata.Metadata[metadata.SnapshotType]
-	timestamp *metadata.Metadata[metadata.TimestampType]
-	targets   map[string]*metadata.Metadata[metadata.TargetsType]
-}
-
-// Root returns metadata of type Root
-func (r *repo) Root() *metadata.Metadata[metadata.RootType] {
-	return r.root
-}
-
-// SetRoot sets metadata of type Root
-func (r *repo) SetRoot(meta *metadata.Metadata[metadata.RootType]) {
-	r.root = meta
-}
-
-// Snapshot returns metadata of type Snapshot
-func (r *repo) Snapshot() *metadata.Metadata[metadata.SnapshotType] {
-	return r.snapshot
-}
-
-// SetSnapshot sets metadata of type Snapshot
-func (r *repo) SetSnapshot(meta *metadata.Metadata[metadata.SnapshotType]) {
-	r.snapshot = meta
-}
-
-// Timestamp returns metadata of type Timestamp
-func (r *repo) Timestamp() *metadata.Metadata[metadata.TimestampType] {
-	return r.timestamp
-}
-
-// SetTimestamp sets metadata of type Timestamp
-func (r *repo) SetTimestamp(meta *metadata.Metadata[metadata.TimestampType]) {
-	r.timestamp = meta
-}
-
-// Targets returns metadata of type Targets
-func (r *repo) Targets(name string) *metadata.Metadata[metadata.TargetsType] {
-	return r.targets[name]
-}
-
-// SetTargets sets metadata of type Targets
-func (r *repo) SetTargets(name string, meta *metadata.Metadata[metadata.TargetsType]) {
-	r.targets[name] = meta
-}
-
-// New creates an empty repository instance
-func newRepo() repo {
-	return repo{
-		targets: map[string]*metadata.Metadata[metadata.TargetsType]{},
-	}
-}
-
 // testRepo is a basic implementation of a TUF repository for testing purposes.
 // It does not support delegates, multiple signers, thresholds, or other
 // advanced TUF features, but it is sufficient for testing the sigstore-go
@@ -309,7 +253,7 @@ func newRepo() repo {
 // primarily intended to test the caching and fetching behavior of the client.
 type testRepo struct {
 	keys  map[string]ed25519.PrivateKey
-	roles repo
+	roles *repository.Type
 	dir   string
 	t     *testing.T
 }
@@ -318,7 +262,7 @@ func newTestRepo(t *testing.T) *testRepo {
 	var err error
 	r := &testRepo{
 		keys:  make(map[string]ed25519.PrivateKey),
-		roles: newRepo(),
+		roles: repository.New(),
 		t:     t,
 	}
 	tomorrow := time.Now().AddDate(0, 0, 1).UTC()


### PR DESCRIPTION
Signed-off-by: Cody Soyland <codysoyland@github.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

This is an extension of #474 which reuses the new `repository.Type` from go-tuf instead of copying it into this project.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
