### PR TITLE
Rename and deprecate SignedEntityVerifier in favor of Verifier

### DIFF
--- a/docs/verification.md
+++ b/docs/verification.md
@@ -36,11 +36,11 @@ This library includes a few abstractions to support different use cases, testing
 
 ## Verifier
 
-The main entrypoint for verification is called `SignedEntityVerifier`, which takes a `TrustedMaterial` and a set of `VerifierOption`s to configure the verification process. A `SignedEntityVerifier` has a single method, `Verify`, which accepts a `SignedEntity` (generally, a Sigstore bundle) and a `Policy` and returns a `VerificationResult`.
+The main entrypoint for verification is called `Verifier`, which takes a `TrustedMaterial` and a set of `VerifierOption`s to configure the verification process. A `Verifier` has a single method, `Verify`, which accepts a `SignedEntity` (generally, a Sigstore bundle) and a `Policy` and returns a `VerificationResult`.
 
 As you can see, there are two places you can provide configuration for the verifier:
 
-- `NewSignedEntityVerifier` - "global options", such as the trusted material, and options for verifying the bundle's signatures, such as thresholds and whether to perform online verification, whether to check for SCTs, etc.
+- `NewVerifier` - "global options", such as the trusted material, and options for verifying the bundle's signatures, such as thresholds and whether to perform online verification, whether to check for SCTs, etc.
 - `Verify` - the bundle to be verified, and options for verifying the bundle's contents, such as asserting a specific subject digest or certificate issuer or SAN
 
 This is compatible with batch workflows where a single verifier is used to verify many bundles, and the bundles themselves may be verified against different identities/artifacts.
@@ -72,7 +72,7 @@ Going through this step-by-step, we'll start by loading the trusted root from th
 Next, we'll create a verifier with some options, which will enable SCT verification, ensure a single transparency log entry, and perform online verification:
 
 ```go
-	sev, err := verify.NewSignedEntityVerifier(trustedMaterial, verify.WithSignedCertificateTimestamps(1), verify.WithTransparencyLog(1), verify.WithObserverTimestamps(1))
+	sev, err := verify.NewVerifier(trustedMaterial, verify.WithSignedCertificateTimestamps(1), verify.WithTransparencyLog(1), verify.WithObserverTimestamps(1))
 	if err != nil {
 		panic(err)
 	}
@@ -202,7 +202,7 @@ func main() {
 		panic(err)
 	}
 
-	sev, err := verify.NewSignedEntityVerifier(trustedMaterial, verify.WithSignedCertificateTimestamps(1), verify.WithTransparencyLog(1), verify.WithObserverTimestamps(1))
+	sev, err := verify.NewVerifier(trustedMaterial, verify.WithSignedCertificateTimestamps(1), verify.WithTransparencyLog(1), verify.WithObserverTimestamps(1))
 	if err != nil {
 		panic(err)
 	}
@@ -308,7 +308,7 @@ func main() {
 		}),
 	}
 
-	sev, err := verify.NewSignedEntityVerifier(trustedMaterial, verify.WithTransparencyLog(1), verify.WithObserverTimestamps(1))
+	sev, err := verify.NewVerifier(trustedMaterial, verify.WithTransparencyLog(1), verify.WithObserverTimestamps(1))
 	if err != nil {
 		panic(err)
 	}

--- a/examples/oci-image-verification/main.go
+++ b/examples/oci-image-verification/main.go
@@ -190,7 +190,7 @@ func run() error {
 		return errors.New("no trusted material provided")
 	}
 
-	sev, err := verify.NewSignedEntityVerifier(trustedMaterial, verifierConfig...)
+	sev, err := verify.NewVerifier(trustedMaterial, verifierConfig...)
 	if err != nil {
 		return err
 	}

--- a/examples/sigstore-go-verification/main.go
+++ b/examples/sigstore-go-verification/main.go
@@ -186,7 +186,7 @@ func run() error {
 		return errors.New("no trusted material provided")
 	}
 
-	sev, err := verify.NewSignedEntityVerifier(trustedMaterial, verifierConfig...)
+	sev, err := verify.NewVerifier(trustedMaterial, verifierConfig...)
 	if err != nil {
 		return err
 	}

--- a/pkg/sign/signer.go
+++ b/pkg/sign/signer.go
@@ -139,7 +139,7 @@ func Bundle(content Content, keypair Keypair, opts BundleOptions) (*protobundle.
 	}
 
 	if opts.TrustedRoot != nil && len(verifierOptions) > 0 {
-		sev, err := verify.NewSignedEntityVerifier(opts.TrustedRoot, verifierOptions...)
+		sev, err := verify.NewVerifier(opts.TrustedRoot, verifierOptions...)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/verify/fuzz_test.go
+++ b/pkg/verify/fuzz_test.go
@@ -108,7 +108,7 @@ func FuzzVerifyArtifactTransparencyLog(f *testing.F) {
 Tests Verify with an entity that contains a randomized
 email and statement and a randomized root
 */
-func FuzzSignedEntityVerifier(f *testing.F) {
+func FuzzVerifier(f *testing.F) {
 	f.Fuzz(func(t *testing.T, trustedrootJSON,
 		bundleBytes []byte) {
 		trustedRoot, err := root.NewTrustedRootFromJSON(trustedrootJSON)
@@ -124,7 +124,7 @@ func FuzzSignedEntityVerifier(f *testing.F) {
 		if err != nil {
 			t.Skip()
 		}
-		v, err := verify.NewSignedEntityVerifier(trustedRoot,
+		v, err := verify.NewVerifier(trustedRoot,
 			verify.WithTransparencyLog(1),
 			verify.WithObserverTimestamps(1))
 		if err != nil {

--- a/pkg/verify/signature_test.go
+++ b/pkg/verify/signature_test.go
@@ -77,7 +77,7 @@ func TestEnvelopeSubject(t *testing.T) {
 	entity, err := virtualSigstore.Attest("foo@example.com", "issuer", statement)
 	assert.NoError(t, err)
 
-	verifier, err := verify.NewSignedEntityVerifier(virtualSigstore, verify.WithTransparencyLog(1), verify.WithSignedTimestamps(1))
+	verifier, err := verify.NewVerifier(virtualSigstore, verify.WithTransparencyLog(1), verify.WithSignedTimestamps(1))
 	assert.NoError(t, err)
 
 	_, err = verifier.Verify(entity, SkipArtifactAndIdentitiesPolicy)
@@ -106,7 +106,7 @@ func TestSignatureVerifierMessageSignature(t *testing.T) {
 	entity, err := virtualSigstore.Sign("foo@example.com", "issuer", []byte(artifact))
 	assert.NoError(t, err)
 
-	verifier, err := verify.NewSignedEntityVerifier(virtualSigstore, verify.WithTransparencyLog(1), verify.WithObserverTimestamps(1))
+	verifier, err := verify.NewVerifier(virtualSigstore, verify.WithTransparencyLog(1), verify.WithObserverTimestamps(1))
 	assert.NoError(t, err)
 
 	result, err := verifier.Verify(entity, verify.NewPolicy(verify.WithArtifact(bytes.NewBufferString(artifact)), verify.WithoutIdentitiesUnsafe()))
@@ -142,7 +142,7 @@ func TestTooManySubjects(t *testing.T) {
 	tooManySubjectsEntity, err := virtualSigstore.Attest("foo@example.com", "issuer", tooManySubjectsStatementBytes)
 	assert.NoError(t, err)
 
-	verifier, err := verify.NewSignedEntityVerifier(virtualSigstore, verify.WithTransparencyLog(1), verify.WithObserverTimestamps(1))
+	verifier, err := verify.NewVerifier(virtualSigstore, verify.WithTransparencyLog(1), verify.WithObserverTimestamps(1))
 	assert.NoError(t, err)
 
 	artifact := "Hi, I am an artifact!" //nolint:goconst
@@ -172,7 +172,7 @@ func TestTooManyDigests(t *testing.T) {
 	tooManySubjectsEntity, err := virtualSigstore.Attest("foo@example.com", "issuer", tooManySubjectsStatementBytes)
 	assert.NoError(t, err)
 
-	verifier, err := verify.NewSignedEntityVerifier(virtualSigstore, verify.WithTransparencyLog(1), verify.WithObserverTimestamps(1))
+	verifier, err := verify.NewVerifier(virtualSigstore, verify.WithTransparencyLog(1), verify.WithObserverTimestamps(1))
 	assert.NoError(t, err)
 
 	artifact := "Hi, I am an artifact!" //nolint:goconst
@@ -230,7 +230,7 @@ func TestVerifyEnvelopeWithMultipleArtifactsAndArtifactDigests(t *testing.T) {
 	entity, err := virtualSigstore.Attest("foo@example.com", "issuer", statement)
 	assert.NoError(t, err)
 
-	verifier, err := verify.NewSignedEntityVerifier(virtualSigstore, verify.WithTransparencyLog(1), verify.WithSignedTimestamps(1))
+	verifier, err := verify.NewVerifier(virtualSigstore, verify.WithTransparencyLog(1), verify.WithSignedTimestamps(1))
 	assert.NoError(t, err)
 
 	_, err = verifier.Verify(entity, verify.NewPolicy(verify.WithArtifacts(artifacts), verify.WithoutIdentitiesUnsafe()))
@@ -332,7 +332,7 @@ func TestCompatibilityAlgorithms(t *testing.T) {
 			entity, err := virtualSigstore.SignWithVersion("foo@example.com", "issuer", []byte(artifact), tt.version)
 			assert.NoError(t, err)
 
-			verifier, err := verify.NewSignedEntityVerifier(virtualSigstore, verify.WithTransparencyLog(1), verify.WithSignedTimestamps(1))
+			verifier, err := verify.NewVerifier(virtualSigstore, verify.WithTransparencyLog(1), verify.WithSignedTimestamps(1))
 			assert.NoError(t, err)
 
 			// Test with full artifact

--- a/pkg/verify/signed_entity.go
+++ b/pkg/verify/signed_entity.go
@@ -109,10 +109,10 @@ func NewVerifier(trustedMaterial root.TrustedMaterial, options ...VerifierOption
 
 // TODO: Remove the following deprecated functions in a future release before sigstore-go 2.0.
 
-// deprecated: Use Verifier instead
+// Deprecated: Use Verifier instead
 type SignedEntityVerifier = Verifier
 
-// deprecated: Use NewVerifier instead
+// Deprecated: Use NewVerifier instead
 func NewSignedEntityVerifier(trustedMaterial root.TrustedMaterial, options ...VerifierOption) (*Verifier, error) {
 	return NewVerifier(trustedMaterial, options...)
 }

--- a/pkg/verify/signed_entity.go
+++ b/pkg/verify/signed_entity.go
@@ -34,7 +34,7 @@ const (
 	VerificationResultMediaType01 = "application/vnd.dev.sigstore.verificationresult+json;version=0.1"
 )
 
-type SignedEntityVerifier struct {
+type Verifier struct {
 	trustedMaterial root.TrustedMaterial
 	config          VerifierConfig
 }
@@ -75,7 +75,7 @@ type VerifierConfig struct { // nolint: revive
 
 type VerifierOption func(*VerifierConfig) error
 
-// NewSignedEntityVerifier creates a new SignedEntityVerifier. It takes a
+// NewVerifier creates a new Verifier. It takes a
 // root.TrustedMaterial, which contains a set of trusted public keys and
 // certificates, and a set of VerifierConfigurators, which set the config
 // that determines the behaviour of the Verify function.
@@ -83,7 +83,7 @@ type VerifierOption func(*VerifierConfig) error
 // VerifierConfig's set of options should match the properties of a given
 // Sigstore deployment, i.e. whether to expect SCTs, Tlog entries, or signed
 // timestamps.
-func NewSignedEntityVerifier(trustedMaterial root.TrustedMaterial, options ...VerifierOption) (*SignedEntityVerifier, error) {
+func NewVerifier(trustedMaterial root.TrustedMaterial, options ...VerifierOption) (*Verifier, error) {
 	var err error
 	c := VerifierConfig{}
 
@@ -99,7 +99,7 @@ func NewSignedEntityVerifier(trustedMaterial root.TrustedMaterial, options ...Ve
 		return nil, err
 	}
 
-	v := &SignedEntityVerifier{
+	v := &Verifier{
 		trustedMaterial: trustedMaterial,
 		config:          c,
 	}
@@ -107,7 +107,17 @@ func NewSignedEntityVerifier(trustedMaterial root.TrustedMaterial, options ...Ve
 	return v, nil
 }
 
-// WithSignedTimestamps configures the SignedEntityVerifier to expect RFC 3161
+// TODO: Remove the following deprecated functions in a future release before sigstore-go 2.0.
+
+// deprecated: Use Verifier instead
+type SignedEntityVerifier = Verifier
+
+// deprecated: Use NewVerifier instead
+func NewSignedEntityVerifier(trustedMaterial root.TrustedMaterial, options ...VerifierOption) (*Verifier, error) {
+	return NewVerifier(trustedMaterial, options...)
+}
+
+// WithSignedTimestamps configures the Verifier to expect RFC 3161
 // timestamps from a Timestamp Authority, verify them using the TrustedMaterial's
 // TimestampingAuthorities(), and, if it exists, use the resulting timestamp(s)
 // to verify the Fulcio certificate.
@@ -122,7 +132,7 @@ func WithSignedTimestamps(threshold int) VerifierOption {
 	}
 }
 
-// WithObserverTimestamps configures the SignedEntityVerifier to expect
+// WithObserverTimestamps configures the Verifier to expect
 // timestamps from either an RFC3161 timestamp authority or a log's
 // SignedEntryTimestamp. These are verified using the TrustedMaterial's
 // TimestampingAuthorities() or RekorLogs(), and used to verify
@@ -138,7 +148,7 @@ func WithObserverTimestamps(threshold int) VerifierOption {
 	}
 }
 
-// WithTransparencyLog configures the SignedEntityVerifier to expect
+// WithTransparencyLog configures the Verifier to expect
 // Transparency Log inclusion proofs or SignedEntryTimestamps, verifying them
 // using the TrustedMaterial's RekorLogs().
 func WithTransparencyLog(threshold int) VerifierOption {
@@ -152,7 +162,7 @@ func WithTransparencyLog(threshold int) VerifierOption {
 	}
 }
 
-// WithIntegratedTimestamps configures the SignedEntityVerifier to
+// WithIntegratedTimestamps configures the Verifier to
 // expect log entry integrated timestamps from either SignedEntryTimestamps
 // or live log lookups.
 func WithIntegratedTimestamps(threshold int) VerifierOption {
@@ -163,7 +173,7 @@ func WithIntegratedTimestamps(threshold int) VerifierOption {
 	}
 }
 
-// WithSignedCertificateTimestamps configures the SignedEntityVerifier to
+// WithSignedCertificateTimestamps configures the Verifier to
 // expect the Fulcio certificate to have a SignedCertificateTimestamp, and
 // verify it using the TrustedMaterial's CTLogAuthorities().
 func WithSignedCertificateTimestamps(threshold int) VerifierOption {
@@ -177,7 +187,7 @@ func WithSignedCertificateTimestamps(threshold int) VerifierOption {
 	}
 }
 
-// WithCurrentTime configures the SignedEntityVerifier to not expect
+// WithCurrentTime configures the Verifier to not expect
 // any timestamps from either a Timestamp Authority or a Transparency Log.
 // This option should not be enabled when verifying short-lived certificates,
 // as an observer timestamp is needed. This option is useful primarily for
@@ -191,7 +201,7 @@ func WithCurrentTime() VerifierOption {
 
 func (c *VerifierConfig) Validate() error {
 	if !c.requireObserverTimestamps && !c.requireSignedTimestamps && !c.requireIntegratedTimestamps && !c.useCurrentTime {
-		return errors.New("when initializing a new SignedEntityVerifier, you must specify at least one of " +
+		return errors.New("when initializing a new Verifier, you must specify at least one of " +
 			"WithObserverTimestamps(), WithSignedTimestamps(), or WithIntegratedTimestamps()")
 	}
 
@@ -548,7 +558,7 @@ func WithArtifactDigests(digests []ArtifactDigest) ArtifactPolicyOption {
 }
 
 // Verify checks the cryptographic integrity of a given SignedEntity according
-// to the options configured in the NewSignedEntityVerifier. Its purpose is to
+// to the options configured in the NewVerifier. Its purpose is to
 // determine whether the SignedEntity was created by a Sigstore deployment we
 // trust, as defined by keys in our TrustedMaterial.
 //
@@ -567,7 +577,7 @@ func WithArtifactDigests(digests []ArtifactDigest) ArtifactPolicyOption {
 //     expected value
 //   - (if the signed entity has a dsse envelope) verify that the envelope's
 //     statement's subject matches the artifact being verified
-func (v *SignedEntityVerifier) Verify(entity SignedEntity, pb PolicyBuilder) (*VerificationResult, error) {
+func (v *Verifier) Verify(entity SignedEntity, pb PolicyBuilder) (*VerificationResult, error) {
 	policy, err := pb.BuildConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to build policy: %w", err)
@@ -765,7 +775,7 @@ func (v *SignedEntityVerifier) Verify(entity SignedEntity, pb PolicyBuilder) (*V
 // a list of verified timestamps from the log integrated timestamps when verifying
 // with observer timestamps.
 // TODO: Return a different verification result for logs specifically (also for #48)
-func (v *SignedEntityVerifier) VerifyTransparencyLogInclusion(entity SignedEntity) ([]TimestampVerificationResult, error) {
+func (v *Verifier) VerifyTransparencyLogInclusion(entity SignedEntity) ([]TimestampVerificationResult, error) {
 	verifiedTimestamps := []TimestampVerificationResult{}
 
 	if v.config.requireTlogEntries {
@@ -791,7 +801,7 @@ func (v *SignedEntityVerifier) VerifyTransparencyLogInclusion(entity SignedEntit
 // logTimestamps may be populated with verified log entry integrated timestamps
 // In order to be verifiable, a SignedEntity must have at least one verified
 // "observer timestamp".
-func (v *SignedEntityVerifier) VerifyObserverTimestamps(entity SignedEntity, logTimestamps []TimestampVerificationResult) ([]TimestampVerificationResult, error) {
+func (v *Verifier) VerifyObserverTimestamps(entity SignedEntity, logTimestamps []TimestampVerificationResult) ([]TimestampVerificationResult, error) {
 	verifiedTimestamps := []TimestampVerificationResult{}
 
 	// From spec:

--- a/test/conformance/main.go
+++ b/test/conformance/main.go
@@ -247,7 +247,7 @@ func main() {
 			verifierConfig = append(verifierConfig, verify.WithTransparencyLog(1), verify.WithIntegratedTimestamps(1))
 		}
 
-		sev, err := verify.NewSignedEntityVerifier(tr, verifierConfig...)
+		sev, err := verify.NewVerifier(tr, verifierConfig...)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/test/fuzz/oss_fuzz_build.sh
+++ b/test/fuzz/oss_fuzz_build.sh
@@ -21,12 +21,12 @@ mkdir pkg/verify/fuzz && mv pkg/verify/fuzz_test.go pkg/verify/fuzz/
 compile_native_go_fuzzer github.com/sigstore/sigstore-go/pkg/verify/fuzz FuzzVerifyTimestampAuthorityWithoutThreshold FuzzVerifyTimestampAuthorityWithoutThreshold
 compile_native_go_fuzzer github.com/sigstore/sigstore-go/pkg/verify/fuzz FuzzVerifyTimestampAuthorityWithThreshold FuzzVerifyTimestampAuthorityWithThreshold
 compile_native_go_fuzzer github.com/sigstore/sigstore-go/pkg/verify/fuzz FuzzVerifyArtifactTransparencyLog FuzzVerifyArtifactTransparencyLog
-compile_native_go_fuzzer github.com/sigstore/sigstore-go/pkg/verify/fuzz FuzzSignedEntityVerifier FuzzSignedEntityVerifier
+compile_native_go_fuzzer github.com/sigstore/sigstore-go/pkg/verify/fuzz FuzzVerifier FuzzVerifier
 compile_native_go_fuzzer github.com/sigstore/sigstore-go/pkg/verify/fuzz FuzzVerifySignatureWithoutArtifactOrDigest FuzzVerifySignatureWithoutArtifactOrDigest
 compile_native_go_fuzzer github.com/sigstore/sigstore-go/pkg/verify/fuzz FuzzVerifySignatureWithArtifactWithoutDigest FuzzVerifySignatureWithArtifactWithoutDigest
 compile_native_go_fuzzer github.com/sigstore/sigstore-go/pkg/verify/fuzz FuzzVerifySignatureWithArtifactDigest FuzzVerifySignatureWithArtifactDigest
 
-zip -j $OUT/FuzzSignedEntityVerifier_seed_corpus.zip examples/trusted-root-public-good.json
+zip -j $OUT/FuzzVerifier_seed_corpus.zip examples/trusted-root-public-good.json
 
 for fuzzer in FuzzVerifyTimestampAuthorityWithoutThreshold FuzzVerifyTimestampAuthorityWithThreshold FuzzVerifyArtifactTransparencyLog FuzzVerifySignatureWithoutArtifactOrDigest FuzzVerifySignatureWithArtifactWithoutDigest FuzzVerifySignatureWithArtifactDigest; do
   cp test/fuzz/dictionaries/intoto_json.dict $OUT/$fuzzer.dict


### PR DESCRIPTION
Signed-off-by: Cody Soyland <codysoyland@github.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

On the road to 1.0, now is our chance to clean up any naming mistakes we made along the way. `SignedEntityVerifier` was intially used to distinguish from other "types" of verifier, but it feels awkward as the main entrypoint for verification. This PR renames `NewSignedEntityVerifier` and `SignedEntityVerifier` to `NewVerifier` and `Verifier`, respectively, for a more friendly developer interface.

Aliases for the old types are added to allow a deprecation period, and these aliases should be removed before sigstore-go 2.0.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
