### PR TITLE
Deprecate and rename VerifyTimestampAuthority/VerifyArtifactTransparencyLog

### DIFF
--- a/pkg/verify/fuzz_test.go
+++ b/pkg/verify/fuzz_test.go
@@ -30,10 +30,10 @@ import (
 var FuzzSkipArtifactAndIdentitiesPolicy = verify.NewPolicy(verify.WithoutArtifactUnsafe(), verify.WithoutIdentitiesUnsafe())
 
 /*
-Tests VerifyTimestampAuthority with an entity that contains
+Tests VerifySignedTimestamp with an entity that contains
 a randomized email and statement
 */
-func FuzzVerifyTimestampAuthorityWithoutThreshold(f *testing.F) {
+func FuzzVerifySignedTimestampWithoutThreshold(f *testing.F) {
 	f.Fuzz(func(t *testing.T, email string, statement []byte) {
 		virtualSigstore, err := ca.NewVirtualSigstore()
 		if err != nil {
@@ -46,16 +46,16 @@ func FuzzVerifyTimestampAuthorityWithoutThreshold(f *testing.F) {
 			t.Skip()
 		}
 		//nolint:errcheck
-		verify.VerifyTimestampAuthority(entity, virtualSigstore)
+		verify.VerifySignedTimestamp(entity, virtualSigstore)
 	})
 }
 
 /*
-Tests VerifyTimestampAuthorityWithThreshold with an entity
+Tests VerifySignedTimestampWithThreshold with an entity
 that contains a randomized email, statement and a randomized
 threshold
 */
-func FuzzVerifyTimestampAuthorityWithThreshold(f *testing.F) {
+func FuzzVerifySignedTimestampWithThreshold(f *testing.F) {
 	f.Fuzz(func(t *testing.T, email string,
 		statement []byte,
 		threshold int) {
@@ -70,18 +70,18 @@ func FuzzVerifyTimestampAuthorityWithThreshold(f *testing.F) {
 			t.Skip()
 		}
 		//nolint:errcheck
-		verify.VerifyTimestampAuthorityWithThreshold(entity,
+		verify.VerifySignedTimestampWithThreshold(entity,
 			virtualSigstore,
 			threshold)
 	})
 }
 
 /*
-Tests VerifyArtifactTransparencyLog with an entity
+Tests VerifyTlogEntry with an entity
 that contains a randomized email and statement and
 a randomized log threshold and integrated time
 */
-func FuzzVerifyArtifactTransparencyLog(f *testing.F) {
+func FuzzVerifyTlogEntry(f *testing.F) {
 	f.Fuzz(func(t *testing.T, email string,
 		statement []byte,
 		logThreshold int,
@@ -97,7 +97,7 @@ func FuzzVerifyArtifactTransparencyLog(f *testing.F) {
 			t.Skip()
 		}
 		//nolint:errcheck
-		verify.VerifyArtifactTransparencyLog(entity,
+		verify.VerifyTlogEntry(entity,
 			virtualSigstore,
 			logThreshold,
 			trustIntegratedTime)

--- a/pkg/verify/signed_entity.go
+++ b/pkg/verify/signed_entity.go
@@ -780,7 +780,7 @@ func (v *Verifier) VerifyTransparencyLogInclusion(entity SignedEntity) ([]Timest
 
 	if v.config.requireTlogEntries {
 		// log timestamps should be verified if with WithIntegratedTimestamps or WithObserverTimestamps is used
-		verifiedTlogTimestamps, err := VerifyArtifactTransparencyLog(entity, v.trustedMaterial, v.config.tlogEntriesThreshold,
+		verifiedTlogTimestamps, err := VerifyTlogEntry(entity, v.trustedMaterial, v.config.tlogEntriesThreshold,
 			v.config.requireIntegratedTimestamps || v.config.requireObserverTimestamps)
 		if err != nil {
 			return nil, err
@@ -807,7 +807,7 @@ func (v *Verifier) VerifyObserverTimestamps(entity SignedEntity, logTimestamps [
 	// From spec:
 	// > … if verification or timestamp parsing fails, the Verifier MUST abort
 	if v.config.requireSignedTimestamps {
-		verifiedSignedTimestamps, err := VerifyTimestampAuthorityWithThreshold(entity, v.trustedMaterial, v.config.signedTimestampThreshold)
+		verifiedSignedTimestamps, err := VerifySignedTimestampWithThreshold(entity, v.trustedMaterial, v.config.signedTimestampThreshold)
 		if err != nil {
 			return nil, err
 		}
@@ -824,7 +824,7 @@ func (v *Verifier) VerifyObserverTimestamps(entity SignedEntity, logTimestamps [
 	}
 
 	if v.config.requireObserverTimestamps {
-		verifiedSignedTimestamps, verificationErrors, err := VerifyTimestampAuthority(entity, v.trustedMaterial)
+		verifiedSignedTimestamps, verificationErrors, err := VerifySignedTimestamp(entity, v.trustedMaterial)
 		if err != nil {
 			return nil, fmt.Errorf("failed to verify signed timestamps: %w", err)
 		}

--- a/pkg/verify/tlog.go
+++ b/pkg/verify/tlog.go
@@ -29,12 +29,12 @@ import (
 
 const maxAllowedTlogEntries = 32
 
-// VerifyArtifactTransparencyLog verifies that the given entity has been logged
+// VerifyTlogEntry verifies that the given entity has been logged
 // in the transparency log and that the log entry is valid.
 //
 // The threshold parameter is the number of unique transparency log entries
 // that must be verified.
-func VerifyArtifactTransparencyLog(entity SignedEntity, trustedMaterial root.TrustedMaterial, logThreshold int, trustIntegratedTime bool) ([]root.Timestamp, error) { //nolint:revive
+func VerifyTlogEntry(entity SignedEntity, trustedMaterial root.TrustedMaterial, logThreshold int, trustIntegratedTime bool) ([]root.Timestamp, error) { //nolint:revive
 	entries, err := entity.TlogEntries()
 	if err != nil {
 		return nil, err
@@ -145,4 +145,11 @@ func getVerifier(publicKey crypto.PublicKey, hashFunc crypto.Hash) (*signature.V
 	}
 
 	return &verifier, nil
+}
+
+// TODO: remove this deprecated function before 2.0
+
+// Deprecated: use VerifyTlogEntry instead
+func VerifyArtifactTransparencyLog(entity SignedEntity, trustedMaterial root.TrustedMaterial, logThreshold int, trustIntegratedTime bool) ([]root.Timestamp, error) {
+	return VerifyTlogEntry(entity, trustedMaterial, logThreshold, trustIntegratedTime)
 }

--- a/pkg/verify/tlog.go
+++ b/pkg/verify/tlog.go
@@ -150,6 +150,6 @@ func getVerifier(publicKey crypto.PublicKey, hashFunc crypto.Hash) (*signature.V
 // TODO: remove this deprecated function before 2.0
 
 // Deprecated: use VerifyTlogEntry instead
-func VerifyArtifactTransparencyLog(entity SignedEntity, trustedMaterial root.TrustedMaterial, logThreshold int, trustIntegratedTime bool) ([]root.Timestamp, error) {
+func VerifyArtifactTransparencyLog(entity SignedEntity, trustedMaterial root.TrustedMaterial, logThreshold int, trustIntegratedTime bool) ([]root.Timestamp, error) { //nolint:revive
 	return VerifyTlogEntry(entity, trustedMaterial, logThreshold, trustIntegratedTime)
 }

--- a/pkg/verify/tsa.go
+++ b/pkg/verify/tsa.go
@@ -110,11 +110,11 @@ func verifySignedTimestamp(signedTimestamp []byte, signatureBytes []byte, truste
 // TODO: remove below deprecated functions before 2.0
 
 // Deprecated: use VerifySignedTimestamp instead.
-func VerifyTimestampAuthority(entity SignedEntity, trustedMaterial root.TrustedMaterial) ([]*root.Timestamp, []error, error) {
+func VerifyTimestampAuthority(entity SignedEntity, trustedMaterial root.TrustedMaterial) ([]*root.Timestamp, []error, error) { //nolint:revive
 	return VerifySignedTimestamp(entity, trustedMaterial)
 }
 
 // Deprecated: use VerifySignedTimestampWithThreshold instead.
-func VerifyTimestampAuthorityWithThreshold(entity SignedEntity, trustedMaterial root.TrustedMaterial, threshold int) ([]*root.Timestamp, error) {
+func VerifyTimestampAuthorityWithThreshold(entity SignedEntity, trustedMaterial root.TrustedMaterial, threshold int) ([]*root.Timestamp, error) { //nolint:revive
 	return VerifySignedTimestampWithThreshold(entity, trustedMaterial, threshold)
 }

--- a/pkg/verify/tsa.go
+++ b/pkg/verify/tsa.go
@@ -23,9 +23,9 @@ import (
 
 const maxAllowedTimestamps = 32
 
-// VerifyTimestampAuthority verifies that the given entity has been timestamped
+// VerifySignedTimestamp verifies that the given entity has been timestamped
 // by a trusted timestamp authority and that the timestamp is valid.
-func VerifyTimestampAuthority(entity SignedEntity, trustedMaterial root.TrustedMaterial) ([]*root.Timestamp, []error, error) { //nolint:revive
+func VerifySignedTimestamp(entity SignedEntity, trustedMaterial root.TrustedMaterial) ([]*root.Timestamp, []error, error) { //nolint:revive
 	signedTimestamps, err := entity.Timestamps()
 	if err != nil {
 		return nil, nil, err
@@ -74,13 +74,13 @@ func isDuplicateTSA(verifiedTimestamps []*root.Timestamp, verifiedSignedTimestam
 	return false
 }
 
-// VerifyTimestampAuthority verifies that the given entity has been timestamped
+// VerifySignedTimestamp verifies that the given entity has been timestamped
 // by a trusted timestamp authority and that the timestamp is valid.
 //
 // The threshold parameter is the number of unique timestamps that must be
 // verified.
-func VerifyTimestampAuthorityWithThreshold(entity SignedEntity, trustedMaterial root.TrustedMaterial, threshold int) ([]*root.Timestamp, error) { //nolint:revive
-	verifiedTimestamps, verificationErrors, err := VerifyTimestampAuthority(entity, trustedMaterial)
+func VerifySignedTimestampWithThreshold(entity SignedEntity, trustedMaterial root.TrustedMaterial, threshold int) ([]*root.Timestamp, error) { //nolint:revive
+	verifiedTimestamps, verificationErrors, err := VerifySignedTimestamp(entity, trustedMaterial)
 	if err != nil {
 		return nil, err
 	}
@@ -105,4 +105,16 @@ func verifySignedTimestamp(signedTimestamp []byte, signatureBytes []byte, truste
 	}
 
 	return nil, fmt.Errorf("unable to verify signed timestamps: %w", errors.Join(errs...))
+}
+
+// TODO: remove below deprecated functions before 2.0
+
+// Deprecated: use VerifySignedTimestamp instead.
+func VerifyTimestampAuthority(entity SignedEntity, trustedMaterial root.TrustedMaterial) ([]*root.Timestamp, []error, error) {
+	return VerifySignedTimestamp(entity, trustedMaterial)
+}
+
+// Deprecated: use VerifySignedTimestampWithThreshold instead.
+func VerifyTimestampAuthorityWithThreshold(entity SignedEntity, trustedMaterial root.TrustedMaterial, threshold int) ([]*root.Timestamp, error) {
+	return VerifySignedTimestampWithThreshold(entity, trustedMaterial, threshold)
 }

--- a/pkg/verify/tsa_test.go
+++ b/pkg/verify/tsa_test.go
@@ -31,22 +31,22 @@ func TestTimestampAuthorityVerifier(t *testing.T) {
 	entity, err := virtualSigstore.Attest("foo@example.com", "issuer", []byte("statement"))
 	assert.NoError(t, err)
 
-	_, err = verify.VerifyTimestampAuthorityWithThreshold(entity, virtualSigstore, 1)
+	_, err = verify.VerifySignedTimestampWithThreshold(entity, virtualSigstore, 1)
 	assert.NoError(t, err)
 
 	virtualSigstore2, err := ca.NewVirtualSigstore()
 	assert.NoError(t, err)
 
-	_, err = verify.VerifyTimestampAuthorityWithThreshold(entity, virtualSigstore2, 1)
+	_, err = verify.VerifySignedTimestampWithThreshold(entity, virtualSigstore2, 1)
 	assert.Error(t, err) // different sigstore instance should fail to verify
 
 	untrustedEntity, err := virtualSigstore2.Attest("foo@example.com", "issuer", []byte("statement"))
 	assert.NoError(t, err)
 
-	_, err = verify.VerifyTimestampAuthorityWithThreshold(&oneTrustedOneUntrustedTimestampEntity{entity, untrustedEntity}, virtualSigstore, 1)
+	_, err = verify.VerifySignedTimestampWithThreshold(&oneTrustedOneUntrustedTimestampEntity{entity, untrustedEntity}, virtualSigstore, 1)
 	assert.NoError(t, err)
 
-	_, err = verify.VerifyTimestampAuthorityWithThreshold(&oneTrustedOneUntrustedTimestampEntity{entity, untrustedEntity}, virtualSigstore, 2)
+	_, err = verify.VerifySignedTimestampWithThreshold(&oneTrustedOneUntrustedTimestampEntity{entity, untrustedEntity}, virtualSigstore, 2)
 	assert.Error(t, err) // only 1 trusted should not meet threshold of 2
 }
 
@@ -63,13 +63,13 @@ func TestTimestampAuthorityVerifierWithoutThreshold(t *testing.T) {
 	var ts []*root.Timestamp
 
 	// expect one verified timestamp
-	ts, verificationErrors, err := verify.VerifyTimestampAuthority(entity, virtualSigstore)
+	ts, verificationErrors, err := verify.VerifySignedTimestamp(entity, virtualSigstore)
 	assert.NoError(t, err)
 	assert.Empty(t, verificationErrors)
 	assert.Len(t, ts, 1)
 
 	// wrong instance; expect no verified timestamps
-	ts, verificationErrors, err = verify.VerifyTimestampAuthority(entity, virtualSigstore2)
+	ts, verificationErrors, err = verify.VerifySignedTimestamp(entity, virtualSigstore2)
 	assert.NoError(t, err)
 	assert.Empty(t, ts)
 	assert.Len(t, verificationErrors, 1)
@@ -115,7 +115,7 @@ func TestDuplicateTimestamps(t *testing.T) {
 	entity, err := virtualSigstore.Attest("foo@example.com", "issuer", []byte("statement"))
 	assert.NoError(t, err)
 
-	timestamps, verificationErrors, err := verify.VerifyTimestampAuthority(&dupTimestampEntity{entity}, virtualSigstore)
+	timestamps, verificationErrors, err := verify.VerifySignedTimestamp(&dupTimestampEntity{entity}, virtualSigstore)
 	assert.ErrorContains(t, verificationErrors[0], "duplicate timestamps from the same authority, ignoring https://virtual.tsa.sigstore.dev")
 	assert.NoError(t, err)
 	assert.Len(t, timestamps, 1)
@@ -136,7 +136,7 @@ func TestBadTSASignature(t *testing.T) {
 	entity, err := virtualSigstore.Attest("foo@example.com", "issuer", []byte("statement"))
 	assert.NoError(t, err)
 
-	_, err = verify.VerifyTimestampAuthorityWithThreshold(&badTSASignatureEntity{entity}, virtualSigstore, 1)
+	_, err = verify.VerifySignedTimestampWithThreshold(&badTSASignatureEntity{entity}, virtualSigstore, 1)
 	assert.Error(t, err)
 }
 
@@ -169,7 +169,7 @@ func TestBadTSACertificateChain(t *testing.T) {
 	entity, err := virtualSigstore.Attest("foo@example.com", "issuer", []byte("statement"))
 	assert.NoError(t, err)
 
-	_, err = verify.VerifyTimestampAuthorityWithThreshold(entity, &customTSAChainTrustedMaterial{VirtualSigstore: virtualSigstore, tsaChain: []root.TimestampingAuthority{badChain}}, 1)
+	_, err = verify.VerifySignedTimestampWithThreshold(entity, &customTSAChainTrustedMaterial{VirtualSigstore: virtualSigstore, tsaChain: []root.TimestampingAuthority{badChain}}, 1)
 	assert.Error(t, err)
 }
 
@@ -219,7 +219,7 @@ func TestBadTSACertificateChainOutsideValidityPeriod(t *testing.T) {
 			entity, err := virtualSigstore.Attest("foo@example.com", "issuer", []byte("statement"))
 			assert.NoError(t, err)
 
-			_, err = verify.VerifyTimestampAuthorityWithThreshold(entity, &customTSAChainTrustedMaterial{VirtualSigstore: virtualSigstore, tsaChain: []root.TimestampingAuthority{test.ca}}, 1)
+			_, err = verify.VerifySignedTimestampWithThreshold(entity, &customTSAChainTrustedMaterial{VirtualSigstore: virtualSigstore, tsaChain: []root.TimestampingAuthority{test.ca}}, 1)
 			if test.err {
 				assert.Error(t, err)
 			} else {
@@ -253,6 +253,6 @@ func TestTooManyTimestamps(t *testing.T) {
 	entity, err := virtualSigstore.Attest("foo@example.com", "issuer", []byte("statement"))
 	assert.NoError(t, err)
 
-	_, err = verify.VerifyTimestampAuthorityWithThreshold(&tooManyTimestampsEntity{entity}, virtualSigstore, 1)
+	_, err = verify.VerifySignedTimestampWithThreshold(&tooManyTimestampsEntity{entity}, virtualSigstore, 1)
 	assert.ErrorContains(t, err, "too many signed timestamps")
 }

--- a/test/fuzz/oss_fuzz_build.sh
+++ b/test/fuzz/oss_fuzz_build.sh
@@ -18,9 +18,9 @@ go get github.com/AdamKorcz/go-118-fuzz-build/testing
 compile_native_go_fuzzer github.com/sigstore/sigstore-go/pkg/bundle FuzzBundle FuzzBundle
 compile_native_go_fuzzer github.com/sigstore/sigstore-go/pkg/tlog FuzzParseEntry FuzzParseEntry
 mkdir pkg/verify/fuzz && mv pkg/verify/fuzz_test.go pkg/verify/fuzz/
-compile_native_go_fuzzer github.com/sigstore/sigstore-go/pkg/verify/fuzz FuzzVerifyTimestampAuthorityWithoutThreshold FuzzVerifyTimestampAuthorityWithoutThreshold
-compile_native_go_fuzzer github.com/sigstore/sigstore-go/pkg/verify/fuzz FuzzVerifyTimestampAuthorityWithThreshold FuzzVerifyTimestampAuthorityWithThreshold
-compile_native_go_fuzzer github.com/sigstore/sigstore-go/pkg/verify/fuzz FuzzVerifyArtifactTransparencyLog FuzzVerifyArtifactTransparencyLog
+compile_native_go_fuzzer github.com/sigstore/sigstore-go/pkg/verify/fuzz FuzzVerifySignedTimestampWithoutThreshold FuzzVerifySignedTimestampWithoutThreshold
+compile_native_go_fuzzer github.com/sigstore/sigstore-go/pkg/verify/fuzz FuzzVerifySignedTimestampWithThreshold FuzzVerifySignedTimestampWithThreshold
+compile_native_go_fuzzer github.com/sigstore/sigstore-go/pkg/verify/fuzz FuzzVerifyTlogEntry FuzzVerifyTlogEntry
 compile_native_go_fuzzer github.com/sigstore/sigstore-go/pkg/verify/fuzz FuzzVerifier FuzzVerifier
 compile_native_go_fuzzer github.com/sigstore/sigstore-go/pkg/verify/fuzz FuzzVerifySignatureWithoutArtifactOrDigest FuzzVerifySignatureWithoutArtifactOrDigest
 compile_native_go_fuzzer github.com/sigstore/sigstore-go/pkg/verify/fuzz FuzzVerifySignatureWithArtifactWithoutDigest FuzzVerifySignatureWithArtifactWithoutDigest
@@ -28,7 +28,7 @@ compile_native_go_fuzzer github.com/sigstore/sigstore-go/pkg/verify/fuzz FuzzVer
 
 zip -j $OUT/FuzzVerifier_seed_corpus.zip examples/trusted-root-public-good.json
 
-for fuzzer in FuzzVerifyTimestampAuthorityWithoutThreshold FuzzVerifyTimestampAuthorityWithThreshold FuzzVerifyArtifactTransparencyLog FuzzVerifySignatureWithoutArtifactOrDigest FuzzVerifySignatureWithArtifactWithoutDigest FuzzVerifySignatureWithArtifactDigest; do
+for fuzzer in FuzzVerifySignedTimestampWithoutThreshold FuzzVerifySignedTimestampWithThreshold FuzzVerifyTlogEntry FuzzVerifySignatureWithoutArtifactOrDigest FuzzVerifySignatureWithArtifactWithoutDigest FuzzVerifySignatureWithArtifactDigest; do
   cp test/fuzz/dictionaries/intoto_json.dict $OUT/$fuzzer.dict
   zip -j $OUT/"$fuzzer"_seed_corpus.zip examples/sigstore-go-signing/intoto.txt
 done 


### PR DESCRIPTION
- Rename VerifyTimestampAuthority to VerifySignedTimestamp
- Rename VerifyTimestampAuthorityWithThreshold to VerifySignedTimestampWithThreshold
- Rename VerifyArtifactTransparencyLog to VerifyTlogEntry
- Add aliases for deprecated functions

Similarly to https://github.com/sigstore/sigstore-go/pull/476, this PR is intended to improve some naming prior to sigstore-go 1.0.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
