### PR TITLE
Error Wrapping in New function

### DIFF
--- a/pkg/tuf/client.go
+++ b/pkg/tuf/client.go
@@ -79,10 +79,10 @@ func New(opts *Options) (*Client, error) {
 	tmpCfg.UnsafeLocalMode = true
 	c.up, err = updater.New(&tmpCfg)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create initial TUF updater: %w", err)
 	}
 	if err = c.loadMetadata(); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to load metadata: %w", err)
 	}
 
 	return &c, nil


### PR DESCRIPTION
The error handling in `updater.New(&tmpCfg)` is currently returned direct, which is not in uniform with other error handling in the TUF client.

This change wraps some meaningful context care of `fmt.Errorf`