### PR TITLE
Avoid naked errors from other modules

### DIFF
--- a/pkg/root/trusted_root.go
+++ b/pkg/root/trusted_root.go
@@ -415,7 +415,7 @@ func FetchTrustedRoot() (*TrustedRoot, error) {
 func FetchTrustedRootWithOptions(opts *tuf.Options) (*TrustedRoot, error) {
 	client, err := tuf.New(opts)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create TUF client %w", err)
 	}
 	return GetTrustedRoot(client)
 }

--- a/pkg/root/trusted_root.go
+++ b/pkg/root/trusted_root.go
@@ -157,7 +157,10 @@ func ParseTransparencyLogs(tlogs []*prototrustroot.TransparencyLogInstance) (tra
 			protocommon.PublicKeyDetails_PKIX_ECDSA_P521_SHA_512:
 			key, err := x509.ParsePKIXPublicKey(tlog.GetPublicKey().GetRawBytes())
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to parse public key for tlog: %s %w",
+					tlog.GetBaseUrl(),
+					err,
+				)
 			}
 			var ecKey *ecdsa.PublicKey
 			var ok bool
@@ -171,7 +174,10 @@ func ParseTransparencyLogs(tlogs []*prototrustroot.TransparencyLogInstance) (tra
 			protocommon.PublicKeyDetails_PKIX_RSA_PKCS1V15_4096_SHA256:
 			key, err := x509.ParsePKIXPublicKey(tlog.GetPublicKey().GetRawBytes())
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to parse public key for tlog: %s %w",
+					tlog.GetBaseUrl(),
+					err,
+				)
 			}
 			var rsaKey *rsa.PublicKey
 			var ok bool
@@ -182,7 +188,10 @@ func ParseTransparencyLogs(tlogs []*prototrustroot.TransparencyLogInstance) (tra
 		case protocommon.PublicKeyDetails_PKIX_ED25519: //nolint:staticcheck
 			key, err := x509.ParsePKIXPublicKey(tlog.GetPublicKey().GetRawBytes())
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to parse public key for tlog: %s %w",
+					tlog.GetBaseUrl(),
+					err,
+				)
 			}
 			var edKey ed25519.PublicKey
 			var ok bool
@@ -194,7 +203,10 @@ func ParseTransparencyLogs(tlogs []*prototrustroot.TransparencyLogInstance) (tra
 		case protocommon.PublicKeyDetails_PKCS1_RSA_PKCS1V5: //nolint:staticcheck
 			key, err := x509.ParsePKCS1PublicKey(tlog.GetPublicKey().GetRawBytes())
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to parse public key for tlog: %s %w",
+					tlog.GetBaseUrl(),
+					err,
+				)
 			}
 			tlogEntry.PublicKey = key
 		default:
@@ -251,7 +263,10 @@ func ParseCertificateAuthority(certAuthority *prototrustroot.CertificateAuthorit
 	for i, cert := range certChain.GetCertificates() {
 		parsedCert, err := x509.ParseCertificate(cert.RawBytes)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to parse certificate for %s %w",
+				certAuthority.Uri,
+				err,
+			)
 		}
 		if i < chainLen-1 {
 			certificateAuthority.Intermediates = append(certificateAuthority.Intermediates, parsedCert)
@@ -307,7 +322,10 @@ func ParseTimestampingAuthority(certAuthority *prototrustroot.CertificateAuthori
 	for i, cert := range certChain.GetCertificates() {
 		parsedCert, err := x509.ParseCertificate(cert.RawBytes)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to parse certificate for %s %w",
+				certAuthority.Uri,
+				err,
+			)
 		}
 		switch {
 		case i == 0 && !parsedCert.IsCA:
@@ -338,7 +356,9 @@ func ParseTimestampingAuthority(certAuthority *prototrustroot.CertificateAuthori
 func NewTrustedRootFromPath(path string) (*TrustedRoot, error) {
 	trustedrootJSON, err := os.ReadFile(path)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to read trusted root %w",
+			err,
+		)
 	}
 
 	return NewTrustedRootFromJSON(trustedrootJSON)
@@ -359,7 +379,7 @@ func NewTrustedRootProtobuf(rootJSON []byte) (*prototrustroot.TrustedRoot, error
 	pbTrustedRoot := &prototrustroot.TrustedRoot{}
 	err := protojson.Unmarshal(rootJSON, pbTrustedRoot)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to proto-json unmarshal trusted root: %w", err)
 	}
 	return pbTrustedRoot, nil
 }
@@ -404,7 +424,9 @@ func FetchTrustedRootWithOptions(opts *tuf.Options) (*TrustedRoot, error) {
 func GetTrustedRoot(c *tuf.Client) (*TrustedRoot, error) {
 	jsonBytes, err := c.GetTarget(defaultTrustedRoot)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get trusted root from TUF client %w",
+			err,
+		)
 	}
 	return NewTrustedRootFromJSON(jsonBytes)
 }
@@ -452,12 +474,12 @@ func NewLiveTrustedRoot(opts *tuf.Options) (*LiveTrustedRoot, error) {
 func NewLiveTrustedRootFromTarget(opts *tuf.Options, target string) (*LiveTrustedRoot, error) {
 	client, err := tuf.New(opts)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create TUF client %w", err)
 	}
 
 	b, err := client.GetTarget(target)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get target from TUF client %w", err)
 	}
 
 	tr, err := NewTrustedRootFromJSON(b)


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Avoid returning naked errors from external packages

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
