### PR TITLE
fail SigstoreTimestampingAuthority) Verify with nil Root

### DIFF
--- a/pkg/root/timestamping_authority.go
+++ b/pkg/root/timestamping_authority.go
@@ -44,6 +44,13 @@ type SigstoreTimestampingAuthority struct {
 var _ TimestampingAuthority = &SigstoreTimestampingAuthority{}
 
 func (tsa *SigstoreTimestampingAuthority) Verify(signedTimestamp []byte, signatureBytes []byte) (*Timestamp, error) {
+	if tsa.Root == nil {
+		var tsaURIDisplay string
+		if tsa.URI != "" {
+			tsaURIDisplay = tsa.URI + " "
+		}
+		return nil, errors.New("timestamping authority " + tsaURIDisplay + "root certificate is nil")
+	}
 	trustedRootVerificationOptions := tsaverification.VerifyOpts{
 		Roots:          []*x509.Certificate{tsa.Root},
 		Intermediates:  tsa.Intermediates,

--- a/pkg/root/timestamping_authority_test.go
+++ b/pkg/root/timestamping_authority_test.go
@@ -156,6 +156,19 @@ func TestTimestampingAuthority(t *testing.T) {
 			expectError:   true,
 		},
 		{
+			name: "nil root",
+			tsa: &root.SigstoreTimestampingAuthority{
+				Root: nil,
+				Intermediates: []*x509.Certificate{
+					intermediateCert,
+				},
+				Leaf: leafCert,
+			},
+			tsrBytes:      tsrBytes,
+			artifactBytes: artifactBytes,
+			expectError:   true,
+		},
+		{
 			name: "signature over wrong artifact",
 			tsa: &root.SigstoreTimestampingAuthority{
 				Root: rootCert,


### PR DESCRIPTION
#### Summary
add a check to SigstoreTimestampingAuthority) Verify and return an error if tsa.Root is present but nil to avoid passing it along in the tsaverification.VerifyOpts.

See issue https://github.com/sigstore/cosign/issues/4261 and
a fix the "downstream" failure https://github.com/sigstore/timestamp-authority/pull/1099.

#### Verification
- cosign built with this change no longer panics
- the unit test for the change in this PR when added to the `main` code causes a [panic](https://gist.github.com/dmitris/84467d676e7412bd01d383ba94e8d022) failure.

#### Release Note
* Bug fixes and fixes of previous known issues
- properly handled  `SigstoreTimestampingAuthority.Root` being `nil` in `SigstoreTimestampingAuthority.Verify`

#### Documentation
N/A
