### PR TITLE
Allow public keys to sign hashedrekord

### DIFF
--- a/examples/sigstore-go-verification/main.go
+++ b/examples/sigstore-go-verification/main.go
@@ -116,11 +116,15 @@ func run() error {
 		verifierConfig = append(verifierConfig, verify.WithTransparencyLog(1))
 	}
 
-	certID, err := verify.NewShortCertificateIdentity(*expectedOIDIssuer, *expectedOIDIssuerRegex, *expectedSAN, *expectedSANRegex)
-	if err != nil {
-		return err
+	if *trustedPublicKey == "" {
+		certID, err := verify.NewShortCertificateIdentity(*expectedOIDIssuer, *expectedOIDIssuerRegex, *expectedSAN, *expectedSANRegex)
+		if err != nil {
+			return err
+		}
+		identityPolicies = append(identityPolicies, verify.WithCertificateIdentity(certID))
+	} else {
+		identityPolicies = append(identityPolicies, verify.WithKey())
 	}
-	identityPolicies = append(identityPolicies, verify.WithCertificateIdentity(certID))
 
 	var trustedMaterial = make(root.TrustedMaterialCollection, 0)
 	var trustedRootJSON []byte

--- a/pkg/sign/transparency.go
+++ b/pkg/sign/transparency.go
@@ -173,8 +173,6 @@ func (r *Rekor) getRekorV2TLE(ctx context.Context, keyOrCertPEM []byte, b *proto
 func (r *Rekor) getRekorV1TLE(ctx context.Context, keyOrCertPEM []byte, b *protobundle.Bundle) (*protorekor.TransparencyLogEntry, error) {
 	dsseEnvelope := b.GetDsseEnvelope()
 	messageSignature := b.GetMessageSignature()
-	verificationMaterial := b.GetVerificationMaterial()
-	bundleCertificate := verificationMaterial.GetCertificate()
 
 	artifactProperties := types.ArtifactProperties{
 		PublicKeyBytes: [][]byte{keyOrCertPEM},
@@ -199,10 +197,6 @@ func (r *Rekor) getRekorV1TLE(ctx context.Context, keyOrCertPEM []byte, b *proto
 		}
 	case messageSignature != nil:
 		hashedrekordType := hashedrekord.New()
-
-		if bundleCertificate == nil {
-			return nil, errors.New("hashedrekord requires X.509 certificate")
-		}
 
 		hexDigest := hex.EncodeToString(messageSignature.MessageDigest.Digest)
 


### PR DESCRIPTION
There was a restriction when signing Rekor v1 hashedrekord entries that required them to use a certificate rather than a public key. This isn't a restriction imposed by Rekor, and it is going to need to have this kind of flexibility if and when this gets used for signing in cosign. This change eliminates the restriction and then updates the examples to show how this could be used.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
