### PR TITLE
Add MarshalJSON to SigningConfig, fix marshaling bug

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "go.buildTags": "e2e"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "go.buildTags": "e2e"
-}

--- a/pkg/root/signing_config.go
+++ b/pkg/root/signing_config.go
@@ -206,14 +206,18 @@ func (s Service) ValidAtTime(t time.Time) bool {
 }
 
 func (s Service) ToServiceProtobuf() *prototrustroot.Service {
+	tr := &v1.TimeRange{
+		Start: timestamppb.New(s.ValidityPeriodStart),
+	}
+	if !s.ValidityPeriodEnd.IsZero() {
+		tr.End = timestamppb.New(s.ValidityPeriodEnd)
+	}
+
 	return &prototrustroot.Service{
 		Url:             s.URL,
 		MajorApiVersion: s.MajorAPIVersion,
-		ValidFor: &v1.TimeRange{
-			Start: timestamppb.New(s.ValidityPeriodStart),
-			End:   timestamppb.New(s.ValidityPeriodEnd),
-		},
-		Operator: s.Operator,
+		ValidFor:        tr,
+		Operator:        s.Operator,
 	}
 }
 
@@ -356,6 +360,10 @@ func (sc SigningConfig) String() string {
 		sc.RekorLogURLs(),
 		sc.TimestampAuthorityURLs(),
 		SigningConfigMediaType02)
+}
+
+func (sc SigningConfig) MarshalJSON() ([]byte, error) {
+	return protojson.Marshal(sc.signingConfig)
 }
 
 // NewSigningConfig initializes a SigningConfig object from a mediaType string, Fulcio certificate

--- a/pkg/root/signing_config_test.go
+++ b/pkg/root/signing_config_test.go
@@ -581,6 +581,7 @@ func TestSigningConfig_FulcioCertificateAuthorityURLs(t *testing.T) {
 						Url:             "https://fulcio.sigstore.dev",
 						MajorApiVersion: 1,
 						ValidFor:        &v1.TimeRange{Start: timestamppb.New(now), End: timestamppb.New(now)},
+						Operator:        "operator",
 					},
 				},
 			},
@@ -590,6 +591,7 @@ func TestSigningConfig_FulcioCertificateAuthorityURLs(t *testing.T) {
 					MajorAPIVersion:     1,
 					ValidityPeriodStart: now,
 					ValidityPeriodEnd:   now,
+					Operator:            "operator",
 				},
 			},
 		},
@@ -628,6 +630,7 @@ func TestSigningConfig_OIDCProviderURLs(t *testing.T) {
 						Url:             "https://oauth2.sigstore.dev/auth",
 						MajorApiVersion: 1,
 						ValidFor:        &v1.TimeRange{Start: timestamppb.New(now), End: timestamppb.New(now)},
+						Operator:        "operator",
 					},
 				},
 			},
@@ -637,6 +640,7 @@ func TestSigningConfig_OIDCProviderURLs(t *testing.T) {
 					MajorAPIVersion:     1,
 					ValidityPeriodStart: now,
 					ValidityPeriodEnd:   now,
+					Operator:            "operator",
 				},
 			},
 		},
@@ -675,6 +679,7 @@ func TestSigningConfig_RekorLogURLs(t *testing.T) {
 						Url:             "https://rekor.sigstore.dev",
 						MajorApiVersion: 1,
 						ValidFor:        &v1.TimeRange{Start: timestamppb.New(now), End: timestamppb.New(now)},
+						Operator:        "operator",
 					},
 				},
 			},
@@ -684,6 +689,7 @@ func TestSigningConfig_RekorLogURLs(t *testing.T) {
 					MajorAPIVersion:     1,
 					ValidityPeriodStart: now,
 					ValidityPeriodEnd:   now,
+					Operator:            "operator",
 				},
 			},
 		},
@@ -759,6 +765,7 @@ func TestSigningConfig_TimestampAuthorityURLs(t *testing.T) {
 						Url:             "https://timestamp.sigstore.dev",
 						MajorApiVersion: 1,
 						ValidFor:        &v1.TimeRange{Start: timestamppb.New(now), End: timestamppb.New(now)},
+						Operator:        "operator",
 					},
 				},
 			},
@@ -768,6 +775,7 @@ func TestSigningConfig_TimestampAuthorityURLs(t *testing.T) {
 					MajorAPIVersion:     1,
 					ValidityPeriodStart: now,
 					ValidityPeriodEnd:   now,
+					Operator:            "operator",
 				},
 			},
 		},
@@ -868,20 +876,20 @@ func TestNewSigningConfig(t *testing.T) {
 			name: "valid",
 			args: args{
 				mediaType:                    SigningConfigMediaType02,
-				fulcioCertificateAuthorities: []Service{{URL: "https://fulcio.sigstore.dev", ValidityPeriodStart: now, ValidityPeriodEnd: now.Add(time.Hour)}},
-				oidcProviders:                []Service{{URL: "https://oauth2.sigstore.dev/auth", ValidityPeriodStart: now, ValidityPeriodEnd: now.Add(time.Hour)}},
-				rekorLogs:                    []Service{{URL: "https://rekor.sigstore.dev", ValidityPeriodStart: now, ValidityPeriodEnd: now.Add(time.Hour)}},
-				timestampAuthorities:         []Service{{URL: "https://timestamp.sigstore.dev", ValidityPeriodStart: now, ValidityPeriodEnd: now.Add(time.Hour)}},
+				fulcioCertificateAuthorities: []Service{{URL: "https://fulcio.sigstore.dev", ValidityPeriodStart: now, ValidityPeriodEnd: now.Add(time.Hour), MajorAPIVersion: 1, Operator: "operator"}},
+				oidcProviders:                []Service{{URL: "https://oauth2.sigstore.dev/auth", ValidityPeriodStart: now, ValidityPeriodEnd: now.Add(time.Hour), MajorAPIVersion: 1, Operator: "operator"}},
+				rekorLogs:                    []Service{{URL: "https://rekor.sigstore.dev", ValidityPeriodStart: now, ValidityPeriodEnd: now.Add(time.Hour), MajorAPIVersion: 1, Operator: "operator"}},
+				timestampAuthorities:         []Service{{URL: "https://timestamp.sigstore.dev", ValidityPeriodStart: now, ValidityPeriodEnd: now.Add(time.Hour), MajorAPIVersion: 1, Operator: "operator"}},
 				config:                       ServiceConfiguration{Selector: prototrustroot.ServiceSelector_ANY},
 			},
 			want: &SigningConfig{
 				signingConfig: &prototrustroot.SigningConfig{
 					MediaType:       SigningConfigMediaType02,
-					CaUrls:          []*prototrustroot.Service{{Url: "https://fulcio.sigstore.dev", ValidFor: &v1.TimeRange{Start: timestamppb.New(now), End: timestamppb.New(now.Add(time.Hour))}}},
-					OidcUrls:        []*prototrustroot.Service{{Url: "https://oauth2.sigstore.dev/auth", ValidFor: &v1.TimeRange{Start: timestamppb.New(now), End: timestamppb.New(now.Add(time.Hour))}}},
-					RekorTlogUrls:   []*prototrustroot.Service{{Url: "https://rekor.sigstore.dev", ValidFor: &v1.TimeRange{Start: timestamppb.New(now), End: timestamppb.New(now.Add(time.Hour))}}},
+					CaUrls:          []*prototrustroot.Service{{Url: "https://fulcio.sigstore.dev", ValidFor: &v1.TimeRange{Start: timestamppb.New(now), End: timestamppb.New(now.Add(time.Hour))}, MajorApiVersion: 1, Operator: "operator"}},
+					OidcUrls:        []*prototrustroot.Service{{Url: "https://oauth2.sigstore.dev/auth", ValidFor: &v1.TimeRange{Start: timestamppb.New(now), End: timestamppb.New(now.Add(time.Hour))}, MajorApiVersion: 1, Operator: "operator"}},
+					RekorTlogUrls:   []*prototrustroot.Service{{Url: "https://rekor.sigstore.dev", ValidFor: &v1.TimeRange{Start: timestamppb.New(now), End: timestamppb.New(now.Add(time.Hour))}, MajorApiVersion: 1, Operator: "operator"}},
 					RekorTlogConfig: &prototrustroot.ServiceConfiguration{Selector: prototrustroot.ServiceSelector_ANY},
-					TsaUrls:         []*prototrustroot.Service{{Url: "https://timestamp.sigstore.dev", ValidFor: &v1.TimeRange{Start: timestamppb.New(now), End: timestamppb.New(now.Add(time.Hour))}}},
+					TsaUrls:         []*prototrustroot.Service{{Url: "https://timestamp.sigstore.dev", ValidFor: &v1.TimeRange{Start: timestamppb.New(now), End: timestamppb.New(now.Add(time.Hour))}, MajorApiVersion: 1, Operator: "operator"}},
 					TsaConfig:       &prototrustroot.ServiceConfiguration{Selector: prototrustroot.ServiceSelector_ANY},
 				},
 			},
@@ -986,6 +994,83 @@ func TestNewSigningConfigWithOptions(t *testing.T) {
 	if !servicesEqual(sc.TimestampAuthorityURLs(), []Service{expectedTSAService, expectedAddedTSAService}) {
 		t.Errorf("unexpected TSA service, expected %v, got %v", expectedTSAService, sc.TimestampAuthorityURLs())
 	}
+}
+
+func TestSigningConfig_MarshalJSON(t *testing.T) {
+	now := time.Unix(1672531200, 0).UTC() // 2023-01-01 00:00:00 +0000 UTC
+	sc, err := NewSigningConfig(
+		SigningConfigMediaType02,
+		[]Service{{URL: "fulcio", MajorAPIVersion: 1, ValidityPeriodStart: now, ValidityPeriodEnd: now.Add(time.Hour), Operator: "operator"}},
+		[]Service{{URL: "oidc", MajorAPIVersion: 1, ValidityPeriodStart: now, Operator: "operator"}}, // No end time
+		[]Service{{URL: "rekor", MajorAPIVersion: 1, ValidityPeriodStart: now, ValidityPeriodEnd: now.Add(time.Hour), Operator: "operator"}},
+		ServiceConfiguration{Selector: prototrustroot.ServiceSelector_ANY, Count: 1},
+		[]Service{{URL: "tsa", MajorAPIVersion: 1, ValidityPeriodStart: now, ValidityPeriodEnd: now.Add(time.Hour), Operator: "operator"}},
+		ServiceConfiguration{Selector: prototrustroot.ServiceSelector_EXACT, Count: 1},
+	)
+	assert.NoError(t, err)
+
+	jsonBytes, err := sc.MarshalJSON()
+	assert.NoError(t, err)
+
+	startTimeStr := "2023-01-01T00:00:00Z"
+	endTimeStr := "2023-01-01T01:00:00Z"
+
+	expectedJSON := fmt.Sprintf(`{
+		"mediaType": "%s",
+		"caUrls": [
+			{
+				"url": "fulcio",
+				"majorApiVersion": 1,
+				"validFor": {
+					"start": "%s",
+					"end": "%s"
+				},
+				"operator": "operator"
+			}
+		],
+		"oidcUrls": [
+			{
+				"url": "oidc",
+				"majorApiVersion": 1,
+				"validFor": {
+					"start": "%s"
+				},
+				"operator": "operator"
+			}
+		],
+		"rekorTlogUrls": [
+			{
+				"url": "rekor",
+				"majorApiVersion": 1,
+				"validFor": {
+					"start": "%s",
+					"end": "%s"
+				},
+				"operator": "operator"
+			}
+		],
+		"rekorTlogConfig": {
+			"selector": "ANY",
+			"count": 1
+		},
+		"tsaUrls": [
+			{
+				"url": "tsa",
+				"majorApiVersion": 1,
+				"validFor": {
+					"start": "%s",
+					"end": "%s"
+				},
+				"operator": "operator"
+			}
+		],
+		"tsaConfig": {
+			"selector": "EXACT",
+			"count": 1
+		}
+	}`, SigningConfigMediaType02, startTimeStr, endTimeStr, startTimeStr, startTimeStr, endTimeStr, startTimeStr, endTimeStr)
+
+	assert.JSONEq(t, expectedJSON, string(jsonBytes))
 }
 
 func TestNewSigningConfigFromPath(t *testing.T) {


### PR DESCRIPTION
This adds a MarshalJSON method to SigningConfig so that clients don't have to construct the proto structure themselves. This also fixes a bug in ToServiceProtobuf where we didn't handle the validity window where end was optional. Test cases have been updated as well to specify validity windows and operators, and I've verified that these tests fail without the bug fix.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
