### PR TITLE
Refactor SelectService to return Service rather than URL, add supported API versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /examples/oci-image-verification/oci-image-verification
 /examples/sigstore-go-signing/sigstore-go-signing
 /examples/sigstore-go-verification/sigstore-go-verification
+/.vscode

--- a/pkg/root/signing_config.go
+++ b/pkg/root/signing_config.go
@@ -73,9 +73,9 @@ func NewService(s *prototrustroot.Service) Service {
 // and current time. It will select the first service with the highest API version that matches
 // the criteria. Services should be sorted from newest to oldest validity period start time, to
 // minimize how far clients need to search to find a matching service.
-func SelectService(services []Service, supportedAPIVersions []uint32, currentTime time.Time) (string, error) {
+func SelectService(services []Service, supportedAPIVersions []uint32, currentTime time.Time) (Service, error) {
 	if len(supportedAPIVersions) == 0 {
-		return "", fmt.Errorf("no supported API versions")
+		return Service{}, fmt.Errorf("no supported API versions")
 	}
 
 	// Order supported versions from highest to lowest
@@ -95,12 +95,12 @@ func SelectService(services []Service, supportedAPIVersions []uint32, currentTim
 	for _, version := range sortedVersions {
 		for _, s := range sortedServices {
 			if version == s.MajorAPIVersion && s.ValidAtTime(currentTime) {
-				return s.URL, nil
+				return s, nil
 			}
 		}
 	}
 
-	return "", fmt.Errorf("no matching service found for API versions %v and current time %v", supportedAPIVersions, currentTime)
+	return Service{}, fmt.Errorf("no matching service found for API versions %v and current time %v", supportedAPIVersions, currentTime)
 }
 
 // SelectServices returns which service endpoints should be used based on supported API versions
@@ -110,7 +110,7 @@ func SelectService(services []Service, supportedAPIVersions []uint32, currentTim
 // It will select services from the highest supported API versions and will not select
 // services from different API versions. It will select distinct service operators, selecting
 // at most one service per operator.
-func SelectServices(services []Service, config ServiceConfiguration, supportedAPIVersions []uint32, currentTime time.Time) ([]string, error) {
+func SelectServices(services []Service, config ServiceConfiguration, supportedAPIVersions []uint32, currentTime time.Time) ([]Service, error) {
 	if len(supportedAPIVersions) == 0 {
 		return nil, fmt.Errorf("no supported API versions")
 	}
@@ -130,36 +130,36 @@ func SelectServices(services []Service, config ServiceConfiguration, supportedAP
 	slices.Reverse(sortedServices)
 
 	operators := make(map[string]bool)
-	var urls []string
+	var selectedServices []Service
 	for _, version := range sortedVersions {
 		for _, s := range sortedServices {
 			if version == s.MajorAPIVersion && s.ValidAtTime(currentTime) {
 				// Select the newest service for a given operator
 				if !operators[s.Operator] {
 					operators[s.Operator] = true
-					urls = append(urls, s.URL)
+					selectedServices = append(selectedServices, s)
 				}
 			}
 		}
 		// Exit once a list of services is found
-		if len(urls) != 0 {
+		if len(selectedServices) != 0 {
 			break
 		}
 	}
 
-	if len(urls) == 0 {
+	if len(selectedServices) == 0 {
 		return nil, fmt.Errorf("no matching services found for API versions %v and current time %v", supportedAPIVersions, currentTime)
 	}
 
 	// Select services from the highest supported API version
 	switch config.Selector {
 	case prototrustroot.ServiceSelector_ALL:
-		return urls, nil
+		return selectedServices, nil
 	case prototrustroot.ServiceSelector_ANY:
-		i := rand.Intn(len(urls)) // #nosec G404
-		return []string{urls[i]}, nil
+		i := rand.Intn(len(selectedServices)) // #nosec G404
+		return []Service{selectedServices[i]}, nil
 	case prototrustroot.ServiceSelector_EXACT:
-		matchedUrls, err := selectExact(urls, config.Count)
+		matchedUrls, err := selectExact(selectedServices, config.Count)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/root/signing_config_test.go
+++ b/pkg/root/signing_config_test.go
@@ -171,7 +171,7 @@ func TestSelectService(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			url, err := SelectService(tt.services, tt.supportedVersions, tt.currentTime)
+			service, err := SelectService(tt.services, tt.supportedVersions, tt.currentTime)
 			if (err != nil) != tt.expectedErr {
 				t.Errorf("SelectService() error = %v, expectedErr %v", err, tt.expectedErr)
 				return
@@ -180,8 +180,8 @@ func TestSelectService(t *testing.T) {
 				if err.Error()[:len(tt.expectedErrMessage)] != tt.expectedErrMessage {
 					t.Errorf("SelectService() error message = %v, expected %v", err.Error(), tt.expectedErrMessage)
 				}
-			} else if url != tt.expectedURL {
-				t.Errorf("SelectService() got = %v, want %v", url, tt.expectedURL)
+			} else if service.URL != tt.expectedURL {
+				t.Errorf("SelectService() got = %v, want %v", service.URL, tt.expectedURL)
 			}
 		})
 	}
@@ -481,10 +481,14 @@ func TestSelectServices(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			urls, err := SelectServices(tt.services, tt.config, tt.supportedVersions, tt.currentTime)
+			services, err := SelectServices(tt.services, tt.config, tt.supportedVersions, tt.currentTime)
 			if (err != nil) != tt.expectedErr {
 				t.Errorf("SelectServices() error = %v, expectedErr %v", err, tt.expectedErr)
 				return
+			}
+			var urls []string
+			for _, s := range services {
+				urls = append(urls, s.URL)
 			}
 			if tt.expectedErr { //nolint:gocritic
 				if err.Error()[:len(tt.expectedErrMessage)] != tt.expectedErrMessage {

--- a/pkg/root/trusted_root.go
+++ b/pkg/root/trusted_root.go
@@ -121,14 +121,13 @@ func ParseTransparencyLogs(tlogs []*prototrustroot.TransparencyLogInstance) (tra
 		if tlog.GetHashAlgorithm() != protocommon.HashAlgorithm_SHA2_256 {
 			return nil, fmt.Errorf("unsupported tlog hash algorithm: %s", tlog.GetHashAlgorithm())
 		}
-		//nolint:staticcheck // Continuing to use log ID
 		if tlog.GetLogId() == nil {
 			return nil, fmt.Errorf("tlog missing log ID")
 		}
-		if tlog.GetLogId().GetKeyId() == nil { //nolint:staticcheck
+		if tlog.GetLogId().GetKeyId() == nil {
 			return nil, fmt.Errorf("tlog missing log ID key ID")
 		}
-		encodedKeyID := hex.EncodeToString(tlog.GetLogId().GetKeyId()) //nolint:staticcheck
+		encodedKeyID := hex.EncodeToString(tlog.GetLogId().GetKeyId())
 
 		if tlog.GetPublicKey() == nil {
 			return nil, fmt.Errorf("tlog missing public key")
@@ -147,7 +146,7 @@ func ParseTransparencyLogs(tlogs []*prototrustroot.TransparencyLogInstance) (tra
 
 		tlogEntry := &TransparencyLog{
 			BaseURL:           tlog.GetBaseUrl(),
-			ID:                tlog.GetLogId().GetKeyId(), //nolint:staticcheck
+			ID:                tlog.GetLogId().GetKeyId(),
 			HashFunc:          hashFunc,
 			SignatureHashFunc: crypto.SHA256,
 		}
@@ -186,7 +185,7 @@ func ParseTransparencyLogs(tlogs []*prototrustroot.TransparencyLogInstance) (tra
 				return nil, fmt.Errorf("tlog public key is not RSA: %s", tlog.GetPublicKey().GetKeyDetails())
 			}
 			tlogEntry.PublicKey = rsaKey
-		case protocommon.PublicKeyDetails_PKIX_ED25519: //nolint:staticcheck
+		case protocommon.PublicKeyDetails_PKIX_ED25519:
 			key, err := x509.ParsePKIXPublicKey(tlog.GetPublicKey().GetRawBytes())
 			if err != nil {
 				return nil, fmt.Errorf("failed to parse public key for tlog: %s %w",

--- a/pkg/sign/certificate.go
+++ b/pkg/sign/certificate.go
@@ -57,6 +57,8 @@ type FulcioOptions struct {
 	Transport http.RoundTripper
 }
 
+var FulcioAPIVersions = []uint32{1}
+
 type fulcioCertRequest struct {
 	PublicKeyRequest publicKeyRequest `json:"publicKeyRequest"`
 }

--- a/pkg/sign/timestamping.go
+++ b/pkg/sign/timestamping.go
@@ -46,6 +46,8 @@ type TimestampAuthority struct {
 	client  *http.Client
 }
 
+var TimestampAuthorityAPIVersions = []uint32{1}
+
 func NewTimestampAuthority(opts *TimestampAuthorityOptions) *TimestampAuthority {
 	ta := &TimestampAuthority{options: opts}
 	ta.client = &http.Client{

--- a/pkg/sign/transparency.go
+++ b/pkg/sign/transparency.go
@@ -79,6 +79,8 @@ type RekorOptions struct {
 	Version  uint32
 }
 
+var RekorAPIVersions = []uint32{1, 2}
+
 func NewRekor(opts *RekorOptions) *Rekor {
 	if opts.Version == 0 {
 		opts.Version = rekorV1

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -133,27 +133,27 @@ func TestSignVerify(t *testing.T) {
 }
 
 func signContent(signingConfig *root.SigningConfig, token string, content sign.Content, rekorVersion uint32, opts sign.BundleOptions) (*protobundle.Bundle, error) {
-	rekorURLs, err := root.SelectServices(signingConfig.RekorLogURLs(), signingConfig.RekorLogURLsConfig(), []uint32{rekorVersion}, time.Now())
+	rekorServices, err := root.SelectServices(signingConfig.RekorLogURLs(), signingConfig.RekorLogURLsConfig(), []uint32{rekorVersion}, time.Now())
 	if err != nil {
 		return nil, err
 	}
-	for _, rekorURL := range rekorURLs {
-		log.Printf("using Rekor URL %s", rekorURL)
+	for _, rekorService := range rekorServices {
+		log.Printf("using Rekor URL %s", rekorService.URL)
 		rekorOpts := &sign.RekorOptions{
-			BaseURL: rekorURL,
+			BaseURL: rekorService.URL,
 			Timeout: time.Duration(90 * time.Second),
 			Retries: 1,
-			Version: rekorVersion,
+			Version: rekorService.MajorAPIVersion,
 		}
 		opts.TransparencyLogs = append(opts.TransparencyLogs, sign.NewRekor(rekorOpts))
 	}
 
-	fulcioURL, err := root.SelectService(signingConfig.FulcioCertificateAuthorityURLs(), []uint32{1}, time.Now())
+	fulcioService, err := root.SelectService(signingConfig.FulcioCertificateAuthorityURLs(), []uint32{1}, time.Now())
 	if err != nil {
 		return nil, err
 	}
 	fulcioOpts := &sign.FulcioOptions{
-		BaseURL: fulcioURL,
+		BaseURL: fulcioService.URL,
 		Timeout: time.Duration(30 * time.Second),
 		Retries: 1,
 	}
@@ -162,13 +162,13 @@ func signContent(signingConfig *root.SigningConfig, token string, content sign.C
 		IDToken: token,
 	}
 
-	tsaURLs, err := root.SelectServices(signingConfig.TimestampAuthorityURLs(), signingConfig.TimestampAuthorityURLsConfig(), []uint32{1}, time.Now())
+	tsaServices, err := root.SelectServices(signingConfig.TimestampAuthorityURLs(), signingConfig.TimestampAuthorityURLsConfig(), []uint32{1}, time.Now())
 	if err != nil {
 		return nil, err
 	}
-	for _, tsaURL := range tsaURLs {
+	for _, tsaService := range tsaServices {
 		tsaOpts := &sign.TimestampAuthorityOptions{
-			URL:     tsaURL,
+			URL:     tsaService.URL,
 			Timeout: time.Duration(30 * time.Second),
 			Retries: 1,
 		}


### PR DESCRIPTION
#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Each signing service implementation sets a global variable for the list
of URLs supported. This avoids clients that use the signing APIs needing
to know which set of service API versions are supported when selecting
services.

This also refactors ServiceService(s) to return the Service struct
itself rather than just a URL, since a signer will need to know the API
version when initializing its client, like for Rekor.

Also removed unnecessary nolints after un-deprecating TrustedRoot's
LogId.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

* Changed return value for root.SelectService and root.SelectServices to return Service struct rather than URL

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
