### PR TITLE
Update GetSigningConfig to use `signing_config.v0.2.json`

### DIFF
--- a/pkg/root/signing_config.go
+++ b/pkg/root/signing_config.go
@@ -449,8 +449,7 @@ func FetchSigningConfigWithOptions(opts *tuf.Options) (*SigningConfig, error) {
 
 // GetSigningConfig fetches the public-good Sigstore signing configuration target from TUF.
 func GetSigningConfig(c *tuf.Client) (*SigningConfig, error) {
-	// TODO(#495): Update to signing_config.v0.2.json once distributed by root-signing and root-signing-staging
-	jsonBytes, err := c.GetTarget("signing_config.json")
+	jsonBytes, err := c.GetTarget("signing_config.v0.2.json")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
`GetSigningConfig` still returns `signing_config.json`:
https://github.com/sigstore/sigstore-go/blob/dcab992b2d5f5c5719258292916e562f9344d0bc/pkg/root/signing_config.go#L452-L453

The tracking bug for this is https://github.com/sigstore/sigstore-go/issues/495, but it was closed without being fixed.

Both the [production](https://github.com/sigstore/root-signing/commit/aa440a9b8612b7d016d6052468e7d5703948f26c) and [staging](https://github.com/sigstore/root-signing-staging/commit/bb447401bbcb5e0be49cfc648ad4d648ba3ca870) TUF repos now have a `signing_config.v0.2.json`, so it should be safe to make this change now.

cc @haydentherapper 

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
