### PR TITLE
Allow no timestamps to be provided when verifying a key

### DIFF
--- a/pkg/verify/signed_entity.go
+++ b/pkg/verify/signed_entity.go
@@ -65,12 +65,15 @@ type VerifierConfig struct { // nolint: revive
 	tlogEntriesThreshold int
 	// requireSCTs requires SCTs in Fulcio certificates
 	requireSCTs bool
-	// ctlogEntriesTreshold is the minimum number of verified SCTs in
+	// ctlogEntriesThreshold is the minimum number of verified SCTs in
 	// a Fulcio certificate
 	ctlogEntriesThreshold int
 	// useCurrentTime uses the current time rather than a provided signed
 	// or log timestamp. Most workflows will not use this option
 	useCurrentTime bool
+	// allowNoTimestamp can be used to skip timestamp checks when a key
+	// is used rather than a certificate.
+	allowNoTimestamp bool
 }
 
 type VerifierOption func(*VerifierConfig) error
@@ -199,10 +202,25 @@ func WithCurrentTime() VerifierOption {
 	}
 }
 
+// WithNoObserverTimestamps configures the Verifier to not expect
+// any timestamps from either a Timestamp Authority or a Transparency Log
+// and to not use the current time to verify a certificate. This may only
+// be used when verifying with keys rather than certificates.
+func WithNoObserverTimestamps() VerifierOption {
+	return func(c *VerifierConfig) error {
+		c.allowNoTimestamp = true
+		return nil
+	}
+}
+
 func (c *VerifierConfig) Validate() error {
-	if !c.requireObserverTimestamps && !c.requireSignedTimestamps && !c.requireIntegratedTimestamps && !c.useCurrentTime {
+	if c.allowNoTimestamp && (c.requireObserverTimestamps || c.requireSignedTimestamps || c.requireIntegratedTimestamps || c.useCurrentTime) {
+		return errors.New("specify WithNoObserverTimestamps() without any other verifier options")
+	}
+	if !c.requireObserverTimestamps && !c.requireSignedTimestamps && !c.requireIntegratedTimestamps && !c.useCurrentTime && !c.allowNoTimestamp {
 		return errors.New("when initializing a new Verifier, you must specify at least one of " +
-			"WithObserverTimestamps(), WithSignedTimestamps(), or WithIntegratedTimestamps()")
+			"WithObserverTimestamps(), WithSignedTimestamps(), WithIntegratedTimestamps() or WithCurrentTime(), " +
+			"or exclusively specify WithNoObserverTimestamps()")
 	}
 
 	return nil
@@ -444,7 +462,7 @@ func WithKey() PolicyOption {
 // DSSE envelope. If the the SignedEntity has a MessageSignature, providing
 // this policy option will cause verification to always fail, since
 // MessageSignatures can only be verified in the presence of an Artifact or
-// artifact digest. See WithArtifact/WithArtifactDigest for more informaiton.
+// artifact digest. See WithArtifact/WithArtifactDigest for more information.
 //
 // Do not use this function unless you know what you are doing!
 //
@@ -610,6 +628,9 @@ func (v *Verifier) Verify(entity SignedEntity, pb PolicyBuilder) (*VerificationR
 	if leafCert := verificationContent.Certificate(); leafCert != nil {
 		if policy.RequireSigningKey() {
 			return nil, errors.New("expected key signature, not certificate")
+		}
+		if v.config.allowNoTimestamp {
+			return nil, errors.New("must provide timestamp to verify certificate")
 		}
 
 		signedWithCertificate = true
@@ -848,7 +869,7 @@ func (v *Verifier) VerifyObserverTimestamps(entity SignedEntity, logTimestamps [
 		verifiedTimestamps = append(verifiedTimestamps, TimestampVerificationResult{Type: "CurrentTime", URI: "", Timestamp: time.Now()})
 	}
 
-	if len(verifiedTimestamps) == 0 {
+	if len(verifiedTimestamps) == 0 && !v.config.allowNoTimestamp {
 		return nil, fmt.Errorf("no valid observer timestamps found")
 	}
 


### PR DESCRIPTION
This adds back an option that allows no timestamps to be provided for verification. This will only work when verifying with a key, and will throw an error if set when trying to verify a certificate.

This is also used when verifying while signing. If a log is used without a timestamp authority, we either verify a certificate with the integrated timestamp or no timestamp for a key. If no log or timestamp is provided, we use current time for a certificate or no timestamp for a key.

Fixes #501
Fixes #502

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
