### PR TITLE
Update OIDC issuer for e2e test

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -64,11 +64,11 @@ func TestSignVerify(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	oidcURL := os.Getenv("OIDC_URL")
-	if oidcURL == "" {
-		t.Fatal("must set OIDC_URL")
+	issuerURL := os.Getenv("ISSUER_URL")
+	if issuerURL == "" {
+		t.Fatal("must set ISSUER_URL")
 	}
-	token, err := getOIDCToken(oidcURL)
+	token, err := getOIDCToken(issuerURL)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -120,7 +120,7 @@ func TestSignVerify(t *testing.T) {
 			protoBundle, err := signContent(signingConfig, token, test.content, test.rekorVersion, opts)
 			assert.NoError(t, err)
 
-			result, err := verifyBundle(protoBundle, oidcURL, defaultCertID, getDigest(artifactData), trustedRoot)
+			result, err := verifyBundle(protoBundle, issuerURL, defaultCertID, getDigest(artifactData), trustedRoot)
 
 			assert.NoError(t, err)
 			assert.NotNil(t, result)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -68,7 +68,11 @@ func TestSignVerify(t *testing.T) {
 	if issuerURL == "" {
 		t.Fatal("must set ISSUER_URL")
 	}
-	token, err := getOIDCToken(issuerURL)
+	oidcURL := os.Getenv("OIDC_URL")
+	if oidcURL == "" {
+		t.Fatal("must set OIDC_URL")
+	}
+	token, err := getOIDCToken(oidcURL)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
In https://github.com/sigstore/scaffolding/pull/1662/, I made a few changes to support running the test suite on macOS. One of these changes required hardcoding an issuer rather than having the issuer be the hostname. The test suite exports an additional variable now, `ISSUER_URL`, that contains the hardcoded issuer value. `OIDC_URL` is just for requesting fresh tokens.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
