### PR TITLE
Support other key algorithms for Rekor v2

### DIFF
--- a/pkg/sign/certificate.go
+++ b/pkg/sign/certificate.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"time"
 
+	protocommon "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
 	"github.com/sigstore/sigstore-go/pkg/util"
 	"github.com/sigstore/sigstore/pkg/oauthflow"
 )
@@ -129,6 +130,11 @@ func (f *Fulcio) GetCertificate(ctx context.Context, keypair Keypair, opts *Cert
 	subject, err := oauthflow.SubjectFromUnverifiedToken(jwtString)
 	if err != nil {
 		return nil, err
+	}
+
+	// Fulcio doesn't support verifying Ed25519ph signatures currently.
+	if keypair.GetSigningAlgorithm() == protocommon.PublicKeyDetails_PKIX_ED25519_PH {
+		return nil, fmt.Errorf("ed25519ph unsupported by Fulcio")
 	}
 
 	// Sign JWT subject for proof of possession

--- a/pkg/sign/certificate_test.go
+++ b/pkg/sign/certificate_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	protocommon "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
 	"github.com/sigstore/sigstore-go/pkg/testing/ca"
 )
 
@@ -156,4 +157,14 @@ func Test_GetCertificate(t *testing.T) {
 	cert, err = detachedFulcio.GetCertificate(ctx, keypair, certOpts)
 	assert.NotNil(t, cert)
 	assert.NoError(t, err)
+
+	t.Run("ed25519ph unsupported", func(t *testing.T) {
+		// Test that Ed25519ph is rejected
+		keypair, err := NewEphemeralKeypair(&EphemeralKeypairOptions{Algorithm: protocommon.PublicKeyDetails_PKIX_ED25519_PH})
+		assert.Nil(t, err)
+		certOpts.IDToken = "idtoken.eyJzdWIiOiJzdWJqZWN0In0K.stuff" // #nosec G101
+		cert, err = fulcio.GetCertificate(ctx, keypair, certOpts)
+		assert.Nil(t, cert)
+		assert.ErrorContains(t, err, "ed25519ph unsupported by Fulcio")
+	})
 }

--- a/pkg/sign/keys_test.go
+++ b/pkg/sign/keys_test.go
@@ -15,43 +15,155 @@
 package sign
 
 import (
+	"bytes"
 	"context"
+	"crypto"
 	"testing"
 
 	protocommon "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
+	"github.com/sigstore/sigstore/pkg/signature"
+	"github.com/sigstore/sigstore/pkg/signature/options"
 	"github.com/stretchr/testify/assert"
 )
 
 func Test_EphemeralKeypair(t *testing.T) {
-	opts := &EphemeralKeypairOptions{
-		Hint: []byte("asdf"),
+	// Test hint logic
+	t.Run("hint", func(t *testing.T) {
+		// with hint
+		opts := &EphemeralKeypairOptions{
+			Hint: []byte("asdf"),
+		}
+		ephemeralKeypair, err := NewEphemeralKeypair(opts)
+		assert.NotNil(t, ephemeralKeypair)
+		assert.Nil(t, err)
+		hint := ephemeralKeypair.GetHint()
+		assert.Equal(t, hint, []byte("asdf"))
+
+		// without hint (default)
+		defaultEphemeralKeypair, err := NewEphemeralKeypair(nil)
+		assert.Nil(t, err)
+		hint = defaultEphemeralKeypair.GetHint()
+		assert.NotEqual(t, hint, []byte(""))
+	})
+
+	// Test different algorithms
+	testCases := []struct {
+		name             string
+		algorithm        protocommon.PublicKeyDetails
+		expectedKeyAlgo  string
+		expectedHashAlgo protocommon.HashAlgorithm
+		cryptoHash       crypto.Hash
+	}{
+		{
+			name:             "default (ECDSA P-256)",
+			algorithm:        protocommon.PublicKeyDetails_PUBLIC_KEY_DETAILS_UNSPECIFIED,
+			expectedKeyAlgo:  "ECDSA",
+			expectedHashAlgo: protocommon.HashAlgorithm_SHA2_256,
+			cryptoHash:       crypto.SHA256,
+		},
+		{
+			name:             "ECDSA P-384",
+			algorithm:        protocommon.PublicKeyDetails_PKIX_ECDSA_P384_SHA_384,
+			expectedKeyAlgo:  "ECDSA",
+			expectedHashAlgo: protocommon.HashAlgorithm_SHA2_384,
+			cryptoHash:       crypto.SHA384,
+		},
+		{
+			name:             "ECDSA P-521",
+			algorithm:        protocommon.PublicKeyDetails_PKIX_ECDSA_P521_SHA_512,
+			expectedKeyAlgo:  "ECDSA",
+			expectedHashAlgo: protocommon.HashAlgorithm_SHA2_512,
+			cryptoHash:       crypto.SHA512,
+		},
+		{
+			name:             "RSA PKCS#1 v1.5 2048",
+			algorithm:        protocommon.PublicKeyDetails_PKIX_RSA_PKCS1V15_2048_SHA256,
+			expectedKeyAlgo:  "RSA",
+			expectedHashAlgo: protocommon.HashAlgorithm_SHA2_256,
+			cryptoHash:       crypto.SHA256,
+		},
+		{
+			name:             "RSA PKCS#1 v1.5 4096",
+			algorithm:        protocommon.PublicKeyDetails_PKIX_RSA_PKCS1V15_4096_SHA256,
+			expectedKeyAlgo:  "RSA",
+			expectedHashAlgo: protocommon.HashAlgorithm_SHA2_256,
+			cryptoHash:       crypto.SHA256,
+		},
+		{
+			name:             "ED25519",
+			algorithm:        protocommon.PublicKeyDetails_PKIX_ED25519,
+			expectedKeyAlgo:  "ED25519",
+			expectedHashAlgo: protocommon.HashAlgorithm_HASH_ALGORITHM_UNSPECIFIED,
+			cryptoHash:       crypto.Hash(0),
+		},
+		{
+			name:             "ED25519ph",
+			algorithm:        protocommon.PublicKeyDetails_PKIX_ED25519_PH,
+			expectedKeyAlgo:  "ED25519",
+			expectedHashAlgo: protocommon.HashAlgorithm_SHA2_512,
+			cryptoHash:       crypto.SHA512,
+		},
 	}
 
-	ctx := context.Background()
-	ephemeralKeypair, err := NewEphemeralKeypair(opts)
-	assert.NotNil(t, ephemeralKeypair)
-	assert.Nil(t, err)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			opts := &EphemeralKeypairOptions{
+				Algorithm: tc.algorithm,
+			}
 
-	hashAlgorithm := ephemeralKeypair.GetHashAlgorithm()
-	assert.Equal(t, hashAlgorithm, protocommon.HashAlgorithm_SHA2_256)
+			ephemeralKeypair, err := NewEphemeralKeypair(opts)
+			assert.NotNil(t, ephemeralKeypair)
+			assert.Nil(t, err)
 
-	hint := ephemeralKeypair.GetHint()
-	assert.Equal(t, hint, []byte("asdf"))
+			hashAlgorithm := ephemeralKeypair.GetHashAlgorithm()
+			assert.Equal(t, tc.expectedHashAlgo, hashAlgorithm)
 
-	keyAlgorithm := ephemeralKeypair.GetKeyAlgorithm()
-	assert.Equal(t, keyAlgorithm, "ECDSA")
+			signingAlgorithm := ephemeralKeypair.GetSigningAlgorithm()
+			expectedAlg := tc.algorithm
+			if tc.algorithm == protocommon.PublicKeyDetails_PUBLIC_KEY_DETAILS_UNSPECIFIED {
+				expectedAlg = protocommon.PublicKeyDetails_PKIX_ECDSA_P256_SHA_256
+			}
+			assert.Equal(t, expectedAlg, signingAlgorithm)
 
-	pem, err := ephemeralKeypair.GetPublicKeyPem()
-	assert.NotEqual(t, pem, "")
-	assert.Nil(t, err)
+			keyAlgorithm := ephemeralKeypair.GetKeyAlgorithm()
+			assert.Equal(t, tc.expectedKeyAlgo, keyAlgorithm)
 
-	signature, digest, err := ephemeralKeypair.SignData(ctx, []byte("hello world"))
-	assert.NotEqual(t, signature, "")
-	assert.NotEqual(t, digest, "")
-	assert.Nil(t, err)
+			pubKey := ephemeralKeypair.GetPublicKey()
+			assert.NotNil(t, pubKey)
 
-	defaultEphemeralKeypair, err := NewEphemeralKeypair(nil)
-	assert.Nil(t, err)
-	hint = defaultEphemeralKeypair.GetHint()
-	assert.NotEqual(t, hint, []byte(""))
+			pem, err := ephemeralKeypair.GetPublicKeyPem()
+			assert.NotEqual(t, pem, "")
+			assert.Nil(t, err)
+
+			dataToSign := []byte("hello world")
+			signatureBytes, digest, err := ephemeralKeypair.SignData(ctx, dataToSign)
+			assert.NotNil(t, signatureBytes)
+			assert.NotNil(t, digest)
+			assert.Nil(t, err)
+
+			// verify signature
+			var loadOpts []signature.LoadOption
+			loadOpts = append(loadOpts, options.WithHash(tc.cryptoHash))
+			if tc.algorithm == protocommon.PublicKeyDetails_PKIX_ED25519_PH {
+				loadOpts = append(loadOpts, options.WithED25519ph())
+			}
+			verifier, err := signature.LoadVerifierWithOpts(pubKey, loadOpts...)
+			assert.Nil(t, err)
+			err = verifier.VerifySignature(bytes.NewReader(signatureBytes), bytes.NewReader(dataToSign))
+			assert.Nil(t, err)
+		})
+	}
+
+	t.Run("unsupported algorithm", func(t *testing.T) {
+		unsupportedAlgorithms := []protocommon.PublicKeyDetails{
+			protocommon.PublicKeyDetails(999), // An arbitrary invalid value
+		}
+
+		for _, alg := range unsupportedAlgorithms {
+			opts := &EphemeralKeypairOptions{Algorithm: alg}
+			_, err := NewEphemeralKeypair(opts)
+			assert.Error(t, err)
+		}
+	})
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package util
+package util // nolint: revive
 
 import (
 	"runtime/debug"

--- a/pkg/verify/signed_entity.go
+++ b/pkg/verify/signed_entity.go
@@ -748,6 +748,11 @@ func (v *Verifier) Verify(entity SignedEntity, pb PolicyBuilder) (*VerificationR
 		result.Signature = &SignatureVerificationResult{
 			Certificate: &certSummary,
 		}
+	} else {
+		pubKeyID := []byte(verificationContent.PublicKey().Hint())
+		result.Signature = &SignatureVerificationResult{
+			PublicKeyID: &pubKeyID,
+		}
 	}
 
 	// SignatureContent can be either an Envelope or a MessageSignature.


### PR DESCRIPTION
We hardcoded ECDSA-P256-SHA256 as the only supported algorithm. This uses the algorithm registry to load the correct signing algorithm to specify its type and digest in the request to Rekor v2. This also fixes an incompatibility with Ed25519 and hashedrekord with Rekor v2, which requires Ed25519ph where the digest is provided during verification.

To test this, I've added support for other signing algorithms in EphemeralKeypair, which will also make the struct useable with Cosign when a signing algorithm is provided.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
