### PR TITLE
Add note regarding API compatibility when using signing config

### DIFF
--- a/examples/sigstore-go-signing/main.go
+++ b/examples/sigstore-go-signing/main.go
@@ -138,6 +138,12 @@ func main() {
 			log.Fatal(err)
 		}
 	} else {
+		// Note to developers: When fetching services from the public-good instance's
+		// SigningConfig, you may retrieve a service with a higher API version than
+		// clients that verify support, e.g. uploading to Rekor v2, but verifying with
+		// a client that only supports Rekor v1. If you are not able to keep verifying
+		// clients up-to-date, you may want to select specific API versions when calling
+		// root.SelectService.
 		signingConfig, err = root.GetSigningConfig(stagingTUFClient)
 		if err != nil {
 			log.Fatal(err)


### PR DESCRIPTION
As discussed in the Go meeting today, we want developers to be aware of the consequences of using a signing config and always selecting the highest API version, which may lead to verifiers unable to verify.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
