### PR TITLE
Bump conformance to latest

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -22,6 +22,8 @@ on:
   pull_request:
     branches:
       - main
+  schedule:
+    - cron: '0 11 * * 1,4' # US work hours
 
 permissions:
   contents: read
@@ -42,11 +44,11 @@ jobs:
 
       - run: go build -o conformance test/conformance/main.go
 
-      - uses: sigstore/sigstore-conformance@244638a7a138ae9f6106cfe2d44a698eccd3bef7 # v0.0.21
+      - uses: sigstore/sigstore-conformance@48320dc345b60e599a447a3d321b71b310c687bb # v0.0.23
         with:
           entrypoint: ${{ github.workspace }}/conformance
 
-      - uses: sigstore/sigstore-conformance@244638a7a138ae9f6106cfe2d44a698eccd3bef7 # v0.0.21
+      - uses: sigstore/sigstore-conformance@48320dc345b60e599a447a3d321b71b310c687bb # v0.0.23
         with:
           entrypoint: ${{ github.workspace }}/conformance
           environment: staging

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -23,7 +23,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: '0 11 * * 1,4' # US work hours
+    - cron: '0 19 * * 1,4' # US work hours
 
 permissions:
   contents: read


### PR DESCRIPTION
To populate https://sigstore.github.io/sigstore-conformance/

Need to run a cron job to have this run from main, since that's where the results will be picked up from.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
