### PR TITLE
Add preferred method for verifying log entry proofs

### DIFF
--- a/pkg/tlog/entry.go
+++ b/pkg/tlog/entry.go
@@ -416,6 +416,7 @@ func (entry *Entry) TransparencyLogEntry() *v1.TransparencyLogEntry {
 }
 
 // VerifyInclusion verifies a Rekor v1-style checkpoint and the entry's inclusion in the Rekor v1 log.
+// Prefer verify.VerifyTlogEntry, which also compares the log entry against a provided bundle.
 func VerifyInclusion(entry *Entry, verifier signature.Verifier) error {
 	hashes := make([]string, len(entry.tle.InclusionProof.Hashes))
 	for i, b := range entry.tle.InclusionProof.Hashes {
@@ -453,6 +454,7 @@ func VerifyInclusion(entry *Entry, verifier signature.Verifier) error {
 
 // VerifyCheckpointAndInclusion verifies a checkpoint and the entry's inclusion in the transparency log.
 // This function is compatible with Rekor v1 and Rekor v2.
+// Prefer verify.VerifyTlogEntry, which also compares the log entry against a provided bundle.
 func VerifyCheckpointAndInclusion(entry *Entry, verifier signature.Verifier, origin string) error {
 	noteVerifier, err := note.NewNoteVerifier(origin, verifier)
 	if err != nil {
@@ -466,6 +468,8 @@ func VerifyCheckpointAndInclusion(entry *Entry, verifier signature.Verifier, ori
 	return nil
 }
 
+// VerifySET verifies the inclusion promise, aka the Signed Entry Timestamp.
+// Prefer verify.VerifyTlogEntry, which also compares the log entry against a provided bundle.
 func VerifySET(entry *Entry, verifiers map[string]*root.TransparencyLog) error {
 	if entry.rekorV1Entry == nil {
 		return fmt.Errorf("can only verify SET for Rekor v1 entry")


### PR DESCRIPTION
A recent vuln report in Cosign was due to a misunderstanding that VerifySET did not perform complete validation of the Rekor entry, in particular a comparison between the bundle's artifact digest, public key and signture, and the entry's contents. This is a minor update to the docstrings for the three log entry verification functions to suggest using the more comprehensive function when possible.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
