### PR TITLE
docs(verify): annotate identity matchers and regexp semantics

### DIFF
--- a/pkg/verify/certificate_identity.go
+++ b/pkg/verify/certificate_identity.go
@@ -23,13 +23,28 @@ import (
 	"github.com/sigstore/sigstore-go/pkg/fulcio/certificate"
 )
 
+// SubjectAlternativeNameMatcher specifies how to match a certificate's Subject
+// Alternative Name (SAN).
 type SubjectAlternativeNameMatcher struct {
-	SubjectAlternativeName string        `json:"subjectAlternativeName"`
-	Regexp                 regexp.Regexp `json:"regexp,omitempty"`
+	// SubjectAlternativeName, if set, must match the certificate SAN exactly.
+	SubjectAlternativeName string `json:"subjectAlternativeName"`
+	// Regexp, if set, is evaluated against the certificate SAN using Go regexp
+	// semantics.
+	//
+	// Note: regexp matching is not anchored by default; use ^...$ if you intend
+	// to match the entire SAN value.
+	Regexp regexp.Regexp `json:"regexp,omitempty"`
 }
 
+// IssuerMatcher specifies how to match a certificate's issuer identity.
 type IssuerMatcher struct {
-	Issuer string        `json:"issuer"`
+	// Issuer, if set, must match the OpenID Connect issuer exactly.
+	Issuer string `json:"issuer"`
+	// Regexp, if set, is evaluated against the OpenID Connect issuer using Go
+	// regexp semantics.
+	//
+	// Note: regexp matching is not anchored by default; use ^...$ if you intend
+	// to match the entire issuer value.
 	Regexp regexp.Regexp `json:"regexp,omitempty"`
 }
 


### PR DESCRIPTION
Thanks for the pointer.

This PR adds GoDoc annotations to SubjectAlternativeNameMatcher and IssuerMatcher (and their fields) around pkg/verify/certificate_identity.go#L26-L34 to make the default Go regexp semantics explicit:

- Regexp.MatchString is substring-based unless the pattern is anchored.
- Added guidance to use ^...$ if callers intend full-string matching.
- Clarified that the exact-value fields (SubjectAlternativeName / Issuer) are exact matches when set.

If you’d prefer this guidance to live elsewhere (for example, pkg/verify docs or a README section), I can move it accordingly.