### PR TITLE
fix(tlog): fail closed for rekor v2 parsing

### DIFF
--- a/pkg/tlog/entry.go
+++ b/pkg/tlog/entry.go
@@ -536,13 +536,18 @@ func unmarshalRekorV2Entry(body []byte) (*rekortilespb.Entry, error) {
 	if err := protojson.Unmarshal(body, &logEntryBody); err != nil {
 		return nil, ErrInvalidRekorV2Entry
 	}
-	if logEntryBody.GetApiVersion() != "0.0.2" {
-		return nil, ErrInvalidRekorV2Entry
-	}
-	switch logEntryBody.GetSpec().GetSpec().(type) {
+
+	spec := logEntryBody.GetSpec().GetSpec()
+	allowedAPIVersion := ""
+	switch spec.(type) {
 	case *rekortilespb.Spec_HashedRekordV002, *rekortilespb.Spec_DsseV002:
-		return &logEntryBody, nil
+		allowedAPIVersion = "0.0.2"
 	default:
 		return nil, ErrInvalidRekorV2Entry
 	}
+	if logEntryBody.GetApiVersion() != allowedAPIVersion {
+		return nil, ErrInvalidRekorV2Entry
+	}
+
+	return &logEntryBody, nil
 }

--- a/pkg/tlog/entry_test.go
+++ b/pkg/tlog/entry_test.go
@@ -19,6 +19,7 @@ import (
 
 	protocommon "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
 	v1 "github.com/sigstore/protobuf-specs/gen/pb-go/rekor/v1"
+	rekortilespb "github.com/sigstore/rekor-tiles/v2/pkg/generated/protobuf"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -249,4 +250,75 @@ func TestPublicKeyUnsupportedEntryType(t *testing.T) {
 	// PublicKey() should not panic even with missing verifier
 	pk := entry.PublicKey()
 	assert.Nil(t, pk, "expected nil PublicKey for entry with no verifier")
+}
+
+func TestNewTlogEntryFallbacksToV1WhenBodyIsRekorV1(t *testing.T) {
+	tle := v1.TransparencyLogEntry{
+		LogIndex: 1,
+		LogId: &protocommon.LogId{
+			KeyId: []byte("logID"),
+		},
+		KindVersion: &v1.KindVersion{
+			Kind:    "apple",
+			Version: "alpha",
+		},
+		CanonicalizedBody: entryBodyV1,
+		InclusionProof: &v1.InclusionProof{
+			LogIndex: 1,
+			TreeSize: 2,
+			RootHash: rootHash,
+			Checkpoint: &v1.Checkpoint{
+				Envelope: string(rootHash),
+			},
+		},
+	}
+
+	entry, err := NewTlogEntry(&tle)
+	assert.NoError(t, err)
+	assert.NotNil(t, entry.rekorV1Entry)
+	assert.Nil(t, entry.rekorV2Entry)
+}
+
+func TestNewTlogEntryRejectsRekorV2WithEmptySpec(t *testing.T) {
+	body := []byte(`{
+  "apiVersion": "0.0.2",
+  "kind": "hashedrekord",
+  "spec": {}
+}`)
+
+	tle := v1.TransparencyLogEntry{
+		LogIndex: 1,
+		LogId: &protocommon.LogId{
+			KeyId: []byte("logID"),
+		},
+		KindVersion: &v1.KindVersion{
+			Kind:    "apple",
+			Version: "alpha",
+		},
+		CanonicalizedBody: body,
+		InclusionProof: &v1.InclusionProof{
+			LogIndex: 1,
+			TreeSize: 2,
+			RootHash: rootHash,
+			Checkpoint: &v1.Checkpoint{
+				Envelope: string(rootHash),
+			},
+		},
+	}
+
+	_, err := NewTlogEntry(&tle)
+	assert.Error(t, err)
+}
+
+func TestValidateEntryRejectsRekorV2WhenSpecIsUnset(t *testing.T) {
+	entry := &Entry{
+		rekorV2Entry: &rekortilespb.Entry{
+			ApiVersion: "0.0.2",
+			Kind:       "hashedrekord",
+			Spec:       &rekortilespb.Spec{},
+		},
+	}
+
+	err := ValidateEntry(entry)
+	assert.Error(t, err)
 }

--- a/pkg/tlog/entry_test.go
+++ b/pkg/tlog/entry_test.go
@@ -15,6 +15,7 @@
 package tlog
 
 import (
+	"bytes"
 	"testing"
 
 	protocommon "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
@@ -308,6 +309,12 @@ func TestNewTlogEntryRejectsRekorV2WithEmptySpec(t *testing.T) {
 
 	_, err := NewTlogEntry(&tle)
 	assert.Error(t, err)
+}
+
+func TestUnmarshalRekorV2EntryRejectsWrongApiVersionForEntryType(t *testing.T) {
+	body := bytes.Replace(entryBodyV2, []byte(`"apiVersion": "0.0.2"`), []byte(`"apiVersion": "0.0.1"`), 1)
+	_, err := unmarshalRekorV2Entry(body)
+	assert.ErrorIs(t, err, ErrInvalidRekorV2Entry)
 }
 
 func TestValidateEntryRejectsRekorV2WhenSpecIsUnset(t *testing.T) {


### PR DESCRIPTION
summary:
- tighten rekor v2 parsing to require `apiVersion: "0.0.2"` and a supported v2 `spec` oneof; otherwise fall back to rekor v1 parsing
- make `ValidateEntry()` fail closed when a rekor v2 entry has an unset/unsupported `spec` oneof
- add tests covering v1 fallback and v2 empty-spec rejection
