### PR TITLE
ensure we have verification material before attempting to extract public key

### DIFF
--- a/pkg/tlog/entry.go
+++ b/pkg/tlog/entry.go
@@ -361,6 +361,9 @@ func (entry *Entry) PublicKey() any {
 			pemString = []byte(*e.IntotoObj.Content.Envelope.Signatures[0].PublicKey)
 		}
 		certBlock, _ := pem.Decode(pemString)
+		if certBlock == nil {
+			return nil
+		}
 		certBytes = certBlock.Bytes
 	} else if entry.rekorV2Entry != nil {
 		var verifier *rekortilespb.Verifier
@@ -369,6 +372,9 @@ func (entry *Entry) PublicKey() any {
 			verifier = e.HashedRekordV002.GetSignature().GetVerifier()
 		case *rekortilespb.Spec_DsseV002:
 			verifier = e.DsseV002.GetSignatures()[0].GetVerifier()
+		}
+		if verifier == nil {
+			return nil
 		}
 		switch verifier.Verifier.(type) {
 		case *rekortilespb.Verifier_PublicKey:


### PR DESCRIPTION
we weren't checking to see if `pem.Decode()` succeeded or whether we had extracted a verifier in case of parsing a rekor v2 bundle. this explicitly checks for this scenarios and adds a unit test case for it.

thanks to @1seal for catching this