### PR TITLE
fix(bundle): cap tlogEntries during JSON parse

### DIFF
--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -15,8 +15,10 @@
 package bundle
 
 import (
+	"bytes"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -45,6 +47,10 @@ var ErrDecodingJSON = fmt.Errorf("%w: decoding json", ErrInvalidAttestation)
 var ErrDecodingB64 = fmt.Errorf("%w: decoding base64", ErrInvalidAttestation)
 
 const mediaTypeBase = "application/vnd.dev.sigstore.bundle"
+
+// defense-in-depth: bound attacker-controlled counts during parse.
+// note: callers should still enforce overall bundle byte-size limits at ingestion.
+const maxAllowedTlogEntries = 100
 
 func ErrValidationError(err error) error {
 	return fmt.Errorf("%w: %w", ErrValidation, err)
@@ -225,7 +231,135 @@ func (b *Bundle) MarshalJSON() ([]byte, error) {
 	return protojson.Marshal(b.Bundle)
 }
 
+func skipJSONValue(dec *json.Decoder) error {
+	tok, err := dec.Token()
+	if err != nil {
+		return err
+	}
+
+	delim, ok := tok.(json.Delim)
+	if !ok {
+		return nil
+	}
+
+	switch delim {
+	case '{':
+		for dec.More() {
+			if _, err := dec.Token(); err != nil { // key
+				return err
+			}
+			if err := skipJSONValue(dec); err != nil { // value
+				return err
+			}
+		}
+		_, err := dec.Token() // '}'
+		return err
+	case '[':
+		for dec.More() {
+			if err := skipJSONValue(dec); err != nil {
+				return err
+			}
+		}
+		_, err := dec.Token() // ']'
+		return err
+	default:
+		return nil
+	}
+}
+
+// enforceTlogEntriesBound fails closed once verificationMaterial.tlogEntries exceeds max.
+// this runs before protojson.Unmarshal to avoid materializing attacker-sized slices during parse.
+func enforceTlogEntriesBound(data []byte, max int) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+
+	tok, err := dec.Token()
+	if err != nil {
+		// preserve prior behavior for invalid JSON (protojson.Unmarshal will surface the decode error).
+		return nil
+	}
+	if tok != json.Delim('{') {
+		return nil
+	}
+
+	for dec.More() {
+		keyTok, err := dec.Token()
+		if err != nil {
+			return nil
+		}
+		key, _ := keyTok.(string)
+		if key != "verificationMaterial" {
+			if err := skipJSONValue(dec); err != nil {
+				return nil
+			}
+			continue
+		}
+
+		vmTok, err := dec.Token()
+		if err != nil {
+			return nil
+		}
+		if vmTok == nil {
+			return nil
+		}
+		if vmTok != json.Delim('{') {
+			if err := skipJSONValue(dec); err != nil {
+				return nil
+			}
+			return nil
+		}
+
+		for dec.More() {
+			vmKeyTok, err := dec.Token()
+			if err != nil {
+				return nil
+			}
+			vmKey, _ := vmKeyTok.(string)
+			if vmKey != "tlogEntries" {
+				if err := skipJSONValue(dec); err != nil {
+					return nil
+				}
+				continue
+			}
+
+			tlogTok, err := dec.Token()
+			if err != nil {
+				return nil
+			}
+			if tlogTok == nil {
+				return nil
+			}
+			if tlogTok != json.Delim('[') {
+				if err := skipJSONValue(dec); err != nil {
+					return nil
+				}
+				return nil
+			}
+
+			count := 0
+			for dec.More() {
+				if err := skipJSONValue(dec); err != nil {
+					return nil
+				}
+				count++
+				if count > max {
+					return fmt.Errorf("too many verificationMaterial.tlogEntries: got=%d max=%d", count, max)
+				}
+			}
+			return nil
+		}
+
+		return nil
+	}
+
+	return nil
+}
+
 func (b *Bundle) UnmarshalJSON(data []byte) error {
+	if err := enforceTlogEntriesBound(data, maxAllowedTlogEntries); err != nil {
+		return ErrValidationError(err)
+	}
+
 	b.Bundle = new(protobundle.Bundle)
 	err := protojson.Unmarshal(data, b.Bundle)
 	if err != nil {

--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -267,7 +267,7 @@ func skipJSONValue(dec *json.Decoder) error {
 	}
 }
 
-// enforceTlogEntriesBound fails closed once verificationMaterial.tlogEntries exceeds max.
+// enforceTlogEntriesBound fails closed once verificationMaterial.tlogEntries exceeds the limit.
 // this runs before protojson.Unmarshal to avoid materializing attacker-sized slices during parse.
 func enforceTlogEntriesBound(data []byte, limit int) error {
 	dec := json.NewDecoder(bytes.NewReader(data))
@@ -303,9 +303,6 @@ func enforceTlogEntriesBound(data []byte, limit int) error {
 			return nil
 		}
 		if vmTok != json.Delim('{') {
-			if err := skipJSONValue(dec); err != nil {
-				return nil
-			}
 			return nil
 		}
 
@@ -330,9 +327,6 @@ func enforceTlogEntriesBound(data []byte, limit int) error {
 				return nil
 			}
 			if tlogTok != json.Delim('[') {
-				if err := skipJSONValue(dec); err != nil {
-					return nil
-				}
 				return nil
 			}
 

--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -307,7 +307,7 @@ func (b *Bundle) TlogEntries() ([]*tlog.Entry, error) {
 
 	if len(b.VerificationMaterial.TlogEntries) > maxAllowedTlogEntries {
 		return nil, ErrValidationError(fmt.Errorf(
-			"too many verificationMaterial.tlogEntries: got=%d max=%d",
+			"too many transparency log entries in the bundle: got=%d max=%d",
 			len(b.VerificationMaterial.TlogEntries),
 			maxAllowedTlogEntries,
 		))

--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -269,7 +269,7 @@ func skipJSONValue(dec *json.Decoder) error {
 
 // enforceTlogEntriesBound fails closed once verificationMaterial.tlogEntries exceeds max.
 // this runs before protojson.Unmarshal to avoid materializing attacker-sized slices during parse.
-func enforceTlogEntriesBound(data []byte, max int) error {
+func enforceTlogEntriesBound(data []byte, limit int) error {
 	dec := json.NewDecoder(bytes.NewReader(data))
 	dec.UseNumber()
 
@@ -342,8 +342,8 @@ func enforceTlogEntriesBound(data []byte, max int) error {
 					return nil
 				}
 				count++
-				if count > max {
-					return fmt.Errorf("too many verificationMaterial.tlogEntries: got=%d max=%d", count, max)
+				if count > limit {
+					return fmt.Errorf("too many verificationMaterial.tlogEntries: got=%d max=%d", count, limit)
 				}
 			}
 			return nil

--- a/pkg/bundle/bundle_test.go
+++ b/pkg/bundle/bundle_test.go
@@ -35,7 +35,7 @@ import (
 
 func buildBundleJSONWithTlogEntries(count int) []byte {
 	var b bytes.Buffer
-	b.WriteString(`{"verificationMaterial":{"tlogEntries":[`)
+	b.WriteString(`{"mediaType":"application/vnd.dev.sigstore.bundle+json;version=0.1","verificationMaterial":{"tlogEntries":[`)
 	for i := 0; i < count; i++ {
 		if i > 0 {
 			b.WriteByte(',')
@@ -68,21 +68,21 @@ func TestBundleUnmarshalJSON_TlogEntriesAtLimitDoesNotTripCap(t *testing.T) {
 
 func TestBundleUnmarshalJSON_TlogEntriesAbsentDoesNotTripCap(t *testing.T) {
 	var b Bundle
-	err := b.UnmarshalJSON([]byte(`{"verificationMaterial":{}}`))
+	err := b.UnmarshalJSON([]byte(`{"mediaType":"application/vnd.dev.sigstore.bundle+json;version=0.1","verificationMaterial":{}}`))
 	require.Error(t, err)
 	require.False(t, strings.Contains(err.Error(), "too many verificationMaterial.tlogEntries"))
 }
 
 func TestBundleUnmarshalJSON_TlogEntriesNullDoesNotTripCap(t *testing.T) {
 	var b Bundle
-	err := b.UnmarshalJSON([]byte(`{"verificationMaterial":{"tlogEntries":null}}`))
+	err := b.UnmarshalJSON([]byte(`{"mediaType":"application/vnd.dev.sigstore.bundle+json;version=0.1","verificationMaterial":{"tlogEntries":null}}`))
 	require.Error(t, err)
 	require.False(t, strings.Contains(err.Error(), "too many verificationMaterial.tlogEntries"))
 }
 
 func TestBundleUnmarshalJSON_TlogEntriesEmptyArrayDoesNotTripCap(t *testing.T) {
 	var b Bundle
-	err := b.UnmarshalJSON([]byte(`{"verificationMaterial":{"tlogEntries":[]}}`))
+	err := b.UnmarshalJSON([]byte(`{"mediaType":"application/vnd.dev.sigstore.bundle+json;version=0.1","verificationMaterial":{"tlogEntries":[]}}`))
 	require.Error(t, err)
 	require.False(t, strings.Contains(err.Error(), "too many verificationMaterial.tlogEntries"))
 }

--- a/pkg/bundle/bundle_test.go
+++ b/pkg/bundle/bundle_test.go
@@ -80,6 +80,13 @@ func TestBundleUnmarshalJSON_TlogEntriesNullDoesNotTripCap(t *testing.T) {
 	require.False(t, strings.Contains(err.Error(), "too many verificationMaterial.tlogEntries"))
 }
 
+func TestBundleUnmarshalJSON_TlogEntriesEmptyArrayDoesNotTripCap(t *testing.T) {
+	var b Bundle
+	err := b.UnmarshalJSON([]byte(`{"verificationMaterial":{"tlogEntries":[]}}`))
+	require.Error(t, err)
+	require.False(t, strings.Contains(err.Error(), "too many verificationMaterial.tlogEntries"))
+}
+
 func Test_getBundleVersion(t *testing.T) {
 	tests := []struct {
 		mediaType string

--- a/pkg/bundle/bundle_test.go
+++ b/pkg/bundle/bundle_test.go
@@ -30,6 +30,7 @@ import (
 	protodsse "github.com/sigstore/protobuf-specs/gen/pb-go/dsse"
 	rekorv1 "github.com/sigstore/protobuf-specs/gen/pb-go/rekor/v1"
 	_ "github.com/sigstore/rekor/pkg/types/hashedrekord"
+	"github.com/sigstore/sigstore-go/pkg/limits"
 	"github.com/stretchr/testify/require"
 )
 
@@ -57,16 +58,16 @@ func TestBundleUnmarshalJSON_TlogEntriesBound(t *testing.T) {
 	}{
 		{
 			name: "over limit fails closed",
-			data: buildBundleJSONWithTlogEntries(maxAllowedTlogEntries + 1),
+			data: buildBundleJSONWithTlogEntries(limits.MaxAllowedTlogEntries + 1),
 			contains: []string{
 				tooManyMsg,
-				fmt.Sprintf("max=%d", maxAllowedTlogEntries),
-				fmt.Sprintf("got=%d", maxAllowedTlogEntries+1),
+				fmt.Sprintf("max=%d", limits.MaxAllowedTlogEntries),
+				fmt.Sprintf("got=%d", limits.MaxAllowedTlogEntries+1),
 			},
 		},
 		{
 			name: "at limit does not trip cap",
-			data: buildBundleJSONWithTlogEntries(maxAllowedTlogEntries),
+			data: buildBundleJSONWithTlogEntries(limits.MaxAllowedTlogEntries),
 			notContains: []string{
 				tooManyMsg,
 			},

--- a/pkg/bundle/bundle_test.go
+++ b/pkg/bundle/bundle_test.go
@@ -66,6 +66,20 @@ func TestBundleUnmarshalJSON_TlogEntriesAtLimitDoesNotTripCap(t *testing.T) {
 	require.False(t, strings.Contains(err.Error(), "too many verificationMaterial.tlogEntries"))
 }
 
+func TestBundleUnmarshalJSON_TlogEntriesAbsentDoesNotTripCap(t *testing.T) {
+	var b Bundle
+	err := b.UnmarshalJSON([]byte(`{"verificationMaterial":{}}`))
+	require.Error(t, err)
+	require.False(t, strings.Contains(err.Error(), "too many verificationMaterial.tlogEntries"))
+}
+
+func TestBundleUnmarshalJSON_TlogEntriesNullDoesNotTripCap(t *testing.T) {
+	var b Bundle
+	err := b.UnmarshalJSON([]byte(`{"verificationMaterial":{"tlogEntries":null}}`))
+	require.Error(t, err)
+	require.False(t, strings.Contains(err.Error(), "too many verificationMaterial.tlogEntries"))
+}
+
 func Test_getBundleVersion(t *testing.T) {
 	tests := []struct {
 		mediaType string

--- a/pkg/limits/limits.go
+++ b/pkg/limits/limits.go
@@ -1,0 +1,23 @@
+// Copyright 2023 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package limits
+
+// MaxAllowedTlogEntries bounds the number of transparency log entries processed
+// from a bundle or entity; this is a defense-in-depth guard against DoS.
+const MaxAllowedTlogEntries = 32
+
+// MaxAllowedTimestamps bounds the number of signed timestamps processed from an
+// entity; this is a defense-in-depth guard against DoS.
+const MaxAllowedTimestamps = 32

--- a/pkg/verify/tlog.go
+++ b/pkg/verify/tlog.go
@@ -24,12 +24,11 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/sigstore/sigstore-go/pkg/limits"
 	"github.com/sigstore/sigstore-go/pkg/root"
 	"github.com/sigstore/sigstore-go/pkg/tlog"
 	"github.com/sigstore/sigstore/pkg/signature"
 )
-
-const maxAllowedTlogEntries = 32
 
 // VerifyTlogEntry verifies that the given entity has been logged
 // in the transparency log and that the log entry is valid.
@@ -43,8 +42,8 @@ func VerifyTlogEntry(entity SignedEntity, trustedMaterial root.TrustedMaterial, 
 	}
 
 	// limit the number of tlog entries to prevent DoS
-	if len(entries) > maxAllowedTlogEntries {
-		return nil, fmt.Errorf("too many tlog entries: %d > %d", len(entries), maxAllowedTlogEntries)
+	if len(entries) > limits.MaxAllowedTlogEntries {
+		return nil, fmt.Errorf("too many tlog entries: %d > %d", len(entries), limits.MaxAllowedTlogEntries)
 	}
 
 	// disallow duplicate entries, as a malicious actor could use duplicates to bypass the threshold

--- a/pkg/verify/tlog_test.go
+++ b/pkg/verify/tlog_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sigstore/sigstore-go/pkg/limits"
 	"github.com/sigstore/sigstore-go/pkg/root"
 	"github.com/sigstore/sigstore-go/pkg/testing/ca"
 	"github.com/sigstore/sigstore-go/pkg/tlog"
@@ -204,7 +205,7 @@ func (e *tooManyTlogEntriesEntity) TlogEntries() ([]*tlog.Entry, error) {
 	if err != nil {
 		return nil, err
 	}
-	for i := 0; i < 32; i++ {
+	for i := 0; i < limits.MaxAllowedTlogEntries; i++ {
 		entries = append(entries, entries[0])
 	}
 

--- a/pkg/verify/tsa.go
+++ b/pkg/verify/tsa.go
@@ -18,10 +18,9 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/sigstore/sigstore-go/pkg/limits"
 	"github.com/sigstore/sigstore-go/pkg/root"
 )
-
-const maxAllowedTimestamps = 32
 
 // VerifySignedTimestamp verifies that the given entity has been timestamped
 // by a trusted timestamp authority and that the timestamp is valid.
@@ -32,8 +31,8 @@ func VerifySignedTimestamp(entity SignedEntity, trustedMaterial root.TrustedMate
 	}
 
 	// limit the number of timestamps to prevent DoS
-	if len(signedTimestamps) > maxAllowedTimestamps {
-		return nil, nil, fmt.Errorf("too many signed timestamps: %d > %d", len(signedTimestamps), maxAllowedTimestamps)
+	if len(signedTimestamps) > limits.MaxAllowedTimestamps {
+		return nil, nil, fmt.Errorf("too many signed timestamps: %d > %d", len(signedTimestamps), limits.MaxAllowedTimestamps)
 	}
 	sigContent, err := entity.SignatureContent()
 	if err != nil {

--- a/pkg/verify/tsa_test.go
+++ b/pkg/verify/tsa_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sigstore/sigstore-go/pkg/limits"
 	"github.com/sigstore/sigstore-go/pkg/root"
 	"github.com/sigstore/sigstore-go/pkg/testing/ca"
 	"github.com/sigstore/sigstore-go/pkg/verify"
@@ -239,7 +240,7 @@ func (e *tooManyTimestampsEntity) Timestamps() ([][]byte, error) {
 		return nil, err
 	}
 
-	for i := 0; i < 32; i++ {
+	for i := 0; i < limits.MaxAllowedTimestamps; i++ {
 		timestamps = append(timestamps, timestamps[0])
 	}
 


### PR DESCRIPTION
summary:
- add a hard upper bound on `verificationMaterial.tlogEntries` in `(*bundle.Bundle).TlogEntries()` before allocating and parsing entries
- keep existing behavior for bundles within the cap (default max=100 as a reasonable upper bound); callers should still enforce overall bundle byte-size limits at ingestion
- add tests covering the cap behavior