### PR TITLE
Support Verification in sigstore/cosign with X.509 Certificate Chain

### DIFF
--- a/internal/certificate/certificate.go
+++ b/internal/certificate/certificate.go
@@ -12,16 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package bundle
+package certificate
 
-// Option configures optional behaviour when constructing a Bundle.
-type Option func(*Bundle)
+import (
+	"bytes"
+	"crypto/x509"
+)
 
-// AllowCertificateChain permits bundles with version >= v0.3 to contain
-// X.509 certificate chains in their verification material. By default,
-// v0.3+ bundles require a single certificate rather than a chain.
-func AllowCertificateChain() Option {
-	return func(b *Bundle) {
-		b.allowCertificateChain = true
+func IsSelfSigned(certificate *x509.Certificate) bool {
+	if !bytes.Equal(certificate.RawSubject, certificate.RawIssuer) {
+		return false
 	}
+	return certificate.CheckSignatureFrom(certificate) == nil
 }

--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -108,14 +108,11 @@ func (b *Bundle) validate() error {
 		}
 	}
 
-	// if bundle version >= v0.3, require verification material to not be X.509 certificate chain (only single certificate is allowed)
-	if semver.Compare(bundleVersion, "v0.3") >= 0 {
-		certs := b.VerificationMaterial.GetX509CertificateChain()
-
-		if certs != nil {
-			return errors.New("verification material cannot be X.509 certificate chain (for bundle v0.3)")
-		}
-	}
+	// Note: v0.3 bundles support both single certificates and certificate chains.
+	// The original constraint requiring single certificates was relaxed to support
+	// BYO-PKI use cases where intermediate CAs are ephemeral and need to be
+	// included in the bundle rather than pre-configured in the trusted root.
+	// See: https://github.com/sigstore/cosign/pull/XXXX for context.
 
 	// if bundle version is >= v0.4, return error as this version is not supported
 	if semver.Compare(bundleVersion, "v0.4") >= 0 {

--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -52,15 +52,20 @@ func ErrValidationError(err error) error {
 
 type Bundle struct {
 	*protobundle.Bundle
-	hasInclusionPromise bool
-	hasInclusionProof   bool
+	hasInclusionPromise   bool
+	hasInclusionProof     bool
+	allowCertificateChain bool
 }
 
-func NewBundle(pbundle *protobundle.Bundle) (*Bundle, error) {
+func NewBundle(pbundle *protobundle.Bundle, opts ...BundleOption) (*Bundle, error) {
 	bundle := &Bundle{
 		Bundle:              pbundle,
 		hasInclusionPromise: false,
 		hasInclusionProof:   false,
+	}
+
+	for _, opt := range opts {
+		opt(bundle)
 	}
 
 	err := bundle.validate()
@@ -105,6 +110,17 @@ func (b *Bundle) validate() error {
 		// if bundle version >= v0.2, require inclusion proof
 		if len(entries) > 0 && !b.hasInclusionProof {
 			return errors.New("inclusion proof missing in bundle (required for bundle v0.2)")
+		}
+	}
+
+	// if bundle version >= v0.3, only allow certificate chain if option is set
+	if semver.Compare(bundleVersion, "v0.3") >= 0 {
+		if !b.allowCertificateChain {
+			certs := b.VerificationMaterial.GetX509CertificateChain()
+
+			if certs != nil {
+				return errors.New("verification material cannot be X.509 certificate chain (for bundle v0.3)")
+			}
 		}
 	}
 
@@ -195,9 +211,13 @@ func validateBundle(b *protobundle.Bundle) error {
 	return nil
 }
 
-func LoadJSONFromPath(path string) (*Bundle, error) {
+func LoadJSONFromPath(path string, opts ...BundleOption) (*Bundle, error) {
 	var bundle Bundle
 	bundle.Bundle = new(protobundle.Bundle)
+
+	for _, opt := range opts {
+		opt(&bundle)
+	}
 
 	contents, err := os.ReadFile(path)
 	if err != nil {

--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -108,12 +108,6 @@ func (b *Bundle) validate() error {
 		}
 	}
 
-	// Note: v0.3 bundles support both single certificates and certificate chains.
-	// The original constraint requiring single certificates was relaxed to support
-	// BYO-PKI use cases where intermediate CAs are ephemeral and need to be
-	// included in the bundle rather than pre-configured in the trusted root.
-	// See: https://github.com/sigstore/cosign/pull/XXXX for context.
-
 	// if bundle version is >= v0.4, return error as this version is not supported
 	if semver.Compare(bundleVersion, "v0.4") >= 0 {
 		return fmt.Errorf("%w: bundle version %s is not yet supported", ErrUnsupportedMediaType, bundleVersion)

--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -57,7 +57,7 @@ type Bundle struct {
 	allowCertificateChain bool
 }
 
-func NewBundle(pbundle *protobundle.Bundle, opts ...BundleOption) (*Bundle, error) {
+func NewBundle(pbundle *protobundle.Bundle, opts ...Option) (*Bundle, error) {
 	bundle := &Bundle{
 		Bundle:              pbundle,
 		hasInclusionPromise: false,
@@ -211,7 +211,7 @@ func validateBundle(b *protobundle.Bundle) error {
 	return nil
 }
 
-func LoadJSONFromPath(path string, opts ...BundleOption) (*Bundle, error) {
+func LoadJSONFromPath(path string, opts ...Option) (*Bundle, error) {
 	var bundle Bundle
 	bundle.Bundle = new(protobundle.Bundle)
 

--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -271,13 +271,15 @@ func (b *Bundle) VerificationContent() (verify.VerificationContent, error) {
 			return nil, ErrValidationError(err)
 		}
 		var intermediates []*x509.Certificate
-		for _, certProto := range certs {
-			intermediate, err := x509.ParseCertificate(certProto.RawBytes)
-			if err != nil {
-				return nil, ErrValidationError(err)
-			}
-			if intermediate.IsCA {
-				intermediates = append(intermediates, intermediate)
+		if b.allowCertificateChain {
+			for _, certificate := range certs[1:] {
+				intermediate, err := x509.ParseCertificate(certificate.RawBytes)
+				if err != nil {
+					return nil, ErrValidationError(err)
+				}
+				if intermediate.IsCA && !verify.IsSelfSigned(intermediate) {
+					intermediates = append(intermediates, intermediate)
+				}
 			}
 		}
 		cert := &Certificate{

--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -300,6 +300,29 @@ func (b *Bundle) VerificationContent() (verify.VerificationContent, error) {
 	}
 }
 
+func (b *Bundle) IntermediateContent() []*x509.Certificate {
+	if b.VerificationMaterial == nil {
+		return nil
+	}
+
+	chain := b.VerificationMaterial.GetX509CertificateChain()
+	if chain == nil {
+		return nil
+	}
+
+	var intermediates []*x509.Certificate
+	for _, certProto := range chain.Certificates {
+		cert, err := x509.ParseCertificate(certProto.RawBytes)
+		if err != nil {
+			continue
+		}
+		if cert.IsCA {
+			intermediates = append(intermediates, cert)
+		}
+	}
+	return intermediates
+}
+
 func (b *Bundle) HasInclusionPromise() bool {
 	return b.hasInclusionPromise
 }

--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -109,12 +109,6 @@ func (b *Bundle) validate() error {
 		}
 	}
 
-	// Note: v0.3 bundles support both single certificates and certificate chains.
-	// The original constraint requiring single certificates was relaxed to support
-	// BYO-PKI use cases where intermediate CAs are ephemeral and need to be
-	// included in the bundle rather than pre-configured in the trusted root.
-	// See: https://github.com/sigstore/cosign/pull/XXXX for context.
-
 	// if bundle version is >= v0.4, return error as this version is not supported
 	if semver.Compare(bundleVersion, "v0.4") >= 0 {
 		return fmt.Errorf("%w: bundle version %s is not yet supported", ErrUnsupportedMediaType, bundleVersion)

--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -270,8 +270,19 @@ func (b *Bundle) VerificationContent() (verify.VerificationContent, error) {
 		if err != nil {
 			return nil, ErrValidationError(err)
 		}
+		var intermediates []*x509.Certificate
+		for _, certProto := range certs {
+			intermediate, err := x509.ParseCertificate(certProto.RawBytes)
+			if err != nil {
+				return nil, ErrValidationError(err)
+			}
+			if intermediate.IsCA {
+				intermediates = append(intermediates, intermediate)
+			}
+		}
 		cert := &Certificate{
-			certificate: parsedCert,
+			certificate:   parsedCert,
+			intermediates: intermediates,
 		}
 		return cert, nil
 	case *protobundle.VerificationMaterial_Certificate:
@@ -298,29 +309,6 @@ func (b *Bundle) VerificationContent() (verify.VerificationContent, error) {
 	default:
 		return nil, ErrMissingVerificationMaterial
 	}
-}
-
-func (b *Bundle) IntermediateContent() []*x509.Certificate {
-	if b.VerificationMaterial == nil {
-		return nil
-	}
-
-	chain := b.VerificationMaterial.GetX509CertificateChain()
-	if chain == nil {
-		return nil
-	}
-
-	var intermediates []*x509.Certificate
-	for _, certProto := range chain.Certificates {
-		cert, err := x509.ParseCertificate(certProto.RawBytes)
-		if err != nil {
-			continue
-		}
-		if cert.IsCA {
-			intermediates = append(intermediates, cert)
-		}
-	}
-	return intermediates
 }
 
 func (b *Bundle) HasInclusionPromise() bool {

--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -53,15 +53,20 @@ func ErrValidationError(err error) error {
 
 type Bundle struct {
 	*protobundle.Bundle
-	hasInclusionPromise bool
-	hasInclusionProof   bool
+	hasInclusionPromise   bool
+	hasInclusionProof     bool
+	allowCertificateChain bool
 }
 
-func NewBundle(pbundle *protobundle.Bundle) (*Bundle, error) {
+func NewBundle(pbundle *protobundle.Bundle, opts ...BundleOption) (*Bundle, error) {
 	bundle := &Bundle{
 		Bundle:              pbundle,
 		hasInclusionPromise: false,
 		hasInclusionProof:   false,
+	}
+
+	for _, opt := range opts {
+		opt(bundle)
 	}
 
 	err := bundle.validate()
@@ -106,6 +111,17 @@ func (b *Bundle) validate() error {
 		// if bundle version >= v0.2, require inclusion proof
 		if len(entries) > 0 && !b.hasInclusionProof {
 			return errors.New("inclusion proof missing in bundle (required for bundle v0.2)")
+		}
+	}
+
+	// if bundle version >= v0.3, only allow certificate chain if option is set
+	if semver.Compare(bundleVersion, "v0.3") >= 0 {
+		if !b.allowCertificateChain {
+			certs := b.VerificationMaterial.GetX509CertificateChain()
+
+			if certs != nil {
+				return errors.New("verification material cannot be X.509 certificate chain (for bundle v0.3)")
+			}
 		}
 	}
 
@@ -196,9 +212,13 @@ func validateBundle(b *protobundle.Bundle) error {
 	return nil
 }
 
-func LoadJSONFromPath(path string) (*Bundle, error) {
+func LoadJSONFromPath(path string, opts ...BundleOption) (*Bundle, error) {
 	var bundle Bundle
 	bundle.Bundle = new(protobundle.Bundle)
+
+	for _, opt := range opts {
+		opt(&bundle)
+	}
 
 	contents, err := os.ReadFile(path)
 	if err != nil {

--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -109,14 +109,11 @@ func (b *Bundle) validate() error {
 		}
 	}
 
-	// if bundle version >= v0.3, require verification material to not be X.509 certificate chain (only single certificate is allowed)
-	if semver.Compare(bundleVersion, "v0.3") >= 0 {
-		certs := b.VerificationMaterial.GetX509CertificateChain()
-
-		if certs != nil {
-			return errors.New("verification material cannot be X.509 certificate chain (for bundle v0.3)")
-		}
-	}
+	// Note: v0.3 bundles support both single certificates and certificate chains.
+	// The original constraint requiring single certificates was relaxed to support
+	// BYO-PKI use cases where intermediate CAs are ephemeral and need to be
+	// included in the bundle rather than pre-configured in the trusted root.
+	// See: https://github.com/sigstore/cosign/pull/XXXX for context.
 
 	// if bundle version is >= v0.4, return error as this version is not supported
 	if semver.Compare(bundleVersion, "v0.4") >= 0 {

--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -58,7 +58,7 @@ type Bundle struct {
 	allowCertificateChain bool
 }
 
-func NewBundle(pbundle *protobundle.Bundle, opts ...BundleOption) (*Bundle, error) {
+func NewBundle(pbundle *protobundle.Bundle, opts ...Option) (*Bundle, error) {
 	bundle := &Bundle{
 		Bundle:              pbundle,
 		hasInclusionPromise: false,
@@ -212,7 +212,7 @@ func validateBundle(b *protobundle.Bundle) error {
 	return nil
 }
 
-func LoadJSONFromPath(path string, opts ...BundleOption) (*Bundle, error) {
+func LoadJSONFromPath(path string, opts ...Option) (*Bundle, error) {
 	var bundle Bundle
 	bundle.Bundle = new(protobundle.Bundle)
 

--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -29,6 +29,7 @@ import (
 	"golang.org/x/mod/semver"
 	"google.golang.org/protobuf/encoding/protojson"
 
+	"github.com/sigstore/sigstore-go/internal/certificate"
 	"github.com/sigstore/sigstore-go/internal/limits"
 	"github.com/sigstore/sigstore-go/pkg/tlog"
 	"github.com/sigstore/sigstore-go/pkg/verify"
@@ -272,14 +273,20 @@ func (b *Bundle) VerificationContent() (verify.VerificationContent, error) {
 		}
 		var intermediates []*x509.Certificate
 		if b.allowCertificateChain {
-			for _, certificate := range certs[1:] {
-				intermediate, err := x509.ParseCertificate(certificate.RawBytes)
+			for _, cert := range certs[1:] {
+				intermediate, err := x509.ParseCertificate(cert.RawBytes)
 				if err != nil {
 					return nil, ErrValidationError(err)
 				}
-				if intermediate.IsCA && !verify.IsSelfSigned(intermediate) {
-					intermediates = append(intermediates, intermediate)
+				// protobuf-specs does not allow signers to include self-signed certificates,
+				// but allows verifiers to tolerate non-compliant bundles for backwards compatibility.
+				if certificate.IsSelfSigned(intermediate) {
+					continue
 				}
+				if !intermediate.IsCA {
+					return nil, ErrValidationError(errors.New("non-CA certificate found in certificate chain"))
+				}
+				intermediates = append(intermediates, intermediate)
 			}
 		}
 		cert := &Certificate{

--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -124,6 +124,8 @@ func (b *Bundle) validate() error {
 				return errors.New("verification material cannot be X.509 certificate chain (for bundle v0.3)")
 			}
 		}
+	} else if b.allowCertificateChain {
+		return errors.New("certificate chain verification is only supported for bundle v0.3 and later")
 	}
 
 	// if bundle version is >= v0.4, return error as this version is not supported
@@ -278,10 +280,8 @@ func (b *Bundle) VerificationContent() (verify.VerificationContent, error) {
 				if err != nil {
 					return nil, ErrValidationError(err)
 				}
-				// protobuf-specs does not allow signers to include self-signed certificates,
-				// but allows verifiers to tolerate non-compliant bundles for backwards compatibility.
 				if certificate.IsSelfSigned(intermediate) {
-					continue
+					return nil, ErrValidationError(errors.New("self-signed certificate found in certificate chain"))
 				}
 				if !intermediate.IsCA {
 					return nil, ErrValidationError(errors.New("non-CA certificate found in certificate chain"))

--- a/pkg/bundle/bundle_test.go
+++ b/pkg/bundle/bundle_test.go
@@ -1039,6 +1039,42 @@ func TestTimestamps(t *testing.T) {
 	}
 }
 
+func TestNewBundleWithAllowCertificateChain(t *testing.T) {
+	t.Parallel()
+
+	v03BundleWithCertChain := &protobundle.Bundle{
+		MediaType: "application/vnd.dev.sigstore.bundle.v0.3+json",
+		VerificationMaterial: &protobundle.VerificationMaterial{
+			Content: &protobundle.VerificationMaterial_X509CertificateChain{
+				X509CertificateChain: &protocommon.X509CertificateChain{},
+			},
+		},
+		Content: &protobundle.Bundle_MessageSignature{},
+	}
+
+	for _, tc := range []struct {
+		name    string
+		opts    []Option
+		wantErr bool
+	}{
+		{"v0.3 with cert chain without option", nil, true},
+		{"v0.3 with cert chain with AllowCertificateChain", []Option{AllowCertificateChain()}, false},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			bundle, err := NewBundle(v03BundleWithCertChain, tc.opts...)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "verification material cannot be X.509 certificate chain")
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, bundle)
+			}
+		})
+	}
+}
+
 func Test_BundleValidation(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/pkg/bundle/bundle_test.go
+++ b/pkg/bundle/bundle_test.go
@@ -1189,7 +1189,7 @@ func TestNewBundleWithAllowCertificateChain(t *testing.T) {
 	}
 }
 
-func TestIntermediateContent(t *testing.T) {
+func TestVerificationContentIntermediates(t *testing.T) {
 	t.Parallel()
 	rootKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
@@ -1222,11 +1222,6 @@ func TestIntermediateContent(t *testing.T) {
 		b         Bundle
 		wantCount int
 	}{
-		{
-			name:      "nil verification material",
-			b:         Bundle{Bundle: &protobundle.Bundle{}},
-			wantCount: 0,
-		},
 		{
 			name: "single certificate (not a chain)",
 			b: Bundle{Bundle: &protobundle.Bundle{
@@ -1291,11 +1286,38 @@ func TestIntermediateContent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := tt.b.IntermediateContent()
+			vc, err := tt.b.VerificationContent()
+			require.NoError(t, err)
+			got := vc.Intermediates()
 			require.Len(t, got, tt.wantCount)
 			for _, cert := range got {
 				require.True(t, cert.IsCA)
 			}
 		})
 	}
+}
+
+func TestVerificationContentIntermediatesParseError(t *testing.T) {
+	t.Parallel()
+	leafKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	leafTmpl := &x509.Certificate{SerialNumber: big.NewInt(1)}
+	leafDer, err := x509.CreateCertificate(rand.Reader, leafTmpl, leafTmpl, &leafKey.PublicKey, leafKey)
+	require.NoError(t, err)
+
+	b := Bundle{Bundle: &protobundle.Bundle{
+		VerificationMaterial: &protobundle.VerificationMaterial{
+			Content: &protobundle.VerificationMaterial_X509CertificateChain{
+				X509CertificateChain: &protocommon.X509CertificateChain{
+					Certificates: []*protocommon.X509Certificate{
+						{RawBytes: leafDer},
+						{RawBytes: []byte("not a certificate")},
+					},
+				},
+			},
+		},
+	}}
+	_, err = b.VerificationContent()
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrValidation)
 }

--- a/pkg/bundle/bundle_test.go
+++ b/pkg/bundle/bundle_test.go
@@ -127,6 +127,7 @@ func TestMinVersion(t *testing.T) {
 		{"blank", "", "", false},
 		{"invalid", "garbage", "v0.1", false},
 	} {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			b := &Bundle{Bundle: &protobundle.Bundle{
@@ -154,6 +155,7 @@ func TestMediaTypeString(t *testing.T) {
 		{"blank", "", "", true},
 		{"invalid", "garbage", "", true},
 	} {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			res, err := MediaTypeString(tc.ver)
@@ -557,6 +559,7 @@ func Test_validate(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.pb.validate()
 			if (got != nil) != tt.wantErr {
@@ -566,130 +569,21 @@ func Test_validate(t *testing.T) {
 	}
 }
 
-func createTestCertChain(t *testing.T) (rootDer, intermediateDer, leafDer []byte) {
-	t.Helper()
-	rootKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	require.NoError(t, err)
-	intermediateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+func TestVerificationContent(t *testing.T) {
+	t.Parallel()
+	caCert := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+	}
+	leafCert := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+	}
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
 	leafKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
-
-	rootCert := &x509.Certificate{
-		SerialNumber:          big.NewInt(1),
-		BasicConstraintsValid: true,
-		IsCA:                  true,
-	}
-	intermediateCert := &x509.Certificate{
-		SerialNumber:          big.NewInt(2),
-		BasicConstraintsValid: true,
-		IsCA:                  true,
-	}
-	leafCertTmpl := &x509.Certificate{
-		SerialNumber: big.NewInt(3),
-	}
-
-	rootDer, err = x509.CreateCertificate(rand.Reader, rootCert, rootCert, &rootKey.PublicKey, rootKey)
-	require.NoError(t, err)
-	intermediateDer, err = x509.CreateCertificate(rand.Reader, intermediateCert, rootCert, &intermediateKey.PublicKey, rootKey)
-	require.NoError(t, err)
-	leafDer, err = x509.CreateCertificate(rand.Reader, leafCertTmpl, intermediateCert, &leafKey.PublicKey, intermediateKey)
-	require.NoError(t, err)
-	return
-}
-
-func TestIntermediateCertificateAuthorities(t *testing.T) {
-	t.Parallel()
-	rootDer, intermediateDer, leafDer := createTestCertChain(t)
-	tests := []struct {
-		name      string
-		b         Bundle
-		wantCount int
-	}{
-		{
-			name:      "nil verification material",
-			b:         Bundle{Bundle: &protobundle.Bundle{}},
-			wantCount: 0,
-		},
-		{
-			name: "single certificate (no chain)",
-			b: Bundle{Bundle: &protobundle.Bundle{
-				VerificationMaterial: &protobundle.VerificationMaterial{
-					Content: &protobundle.VerificationMaterial_Certificate{
-						Certificate: &protocommon.X509Certificate{RawBytes: leafDer},
-					},
-				},
-			}},
-			wantCount: 0,
-		},
-		{
-			name: "chain with leaf and intermediate",
-			b: Bundle{Bundle: &protobundle.Bundle{
-				VerificationMaterial: &protobundle.VerificationMaterial{
-					Content: &protobundle.VerificationMaterial_X509CertificateChain{
-						X509CertificateChain: &protocommon.X509CertificateChain{
-							Certificates: []*protocommon.X509Certificate{
-								{RawBytes: leafDer},
-								{RawBytes: intermediateDer},
-							},
-						},
-					},
-				},
-			}},
-			wantCount: 1,
-		},
-		{
-			name: "chain with leaf intermediate and root",
-			b: Bundle{Bundle: &protobundle.Bundle{
-				VerificationMaterial: &protobundle.VerificationMaterial{
-					Content: &protobundle.VerificationMaterial_X509CertificateChain{
-						X509CertificateChain: &protocommon.X509CertificateChain{
-							Certificates: []*protocommon.X509Certificate{
-								{RawBytes: leafDer},
-								{RawBytes: intermediateDer},
-								{RawBytes: rootDer},
-							},
-						},
-					},
-				},
-			}},
-			wantCount: 2,
-		},
-		{
-			name: "chain with only leaf",
-			b: Bundle{Bundle: &protobundle.Bundle{
-				VerificationMaterial: &protobundle.VerificationMaterial{
-					Content: &protobundle.VerificationMaterial_X509CertificateChain{
-						X509CertificateChain: &protocommon.X509CertificateChain{
-							Certificates: []*protocommon.X509Certificate{
-								{RawBytes: leafDer},
-							},
-						},
-					},
-				},
-			}},
-			wantCount: 0,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			got := tt.b.IntermediateContent()
-			require.Len(t, got, tt.wantCount)
-			for _, cert := range got {
-				require.True(t, cert.IsCA)
-			}
-		})
-	}
-}
-
-func TestVerificationContent(t *testing.T) {
-	t.Parallel()
-	_, _, leafDer := createTestCertChain(t)
-	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	require.NoError(t, err)
-	caCert := &x509.Certificate{SerialNumber: big.NewInt(100)}
 	caDer, err := x509.CreateCertificate(rand.Reader, caCert, caCert, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+	leafDer, err := x509.CreateCertificate(rand.Reader, leafCert, caCert, &leafKey.PublicKey, caKey)
 	require.NoError(t, err)
 	tests := []struct {
 		name            string
@@ -913,6 +807,7 @@ func TestVerificationContent(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got, gotErr := tt.pb.VerificationContent()
 			if tt.wantErr {
@@ -999,6 +894,7 @@ func TestSignatureContent(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got, gotErr := tt.pb.SignatureContent()
 			if tt.wantErr {
@@ -1053,6 +949,7 @@ func TestEnvelope(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			_, gotErr := tt.pb.Envelope()
 			if tt.wantErr {
@@ -1130,6 +1027,7 @@ func TestTimestamps(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got, gotErr := tt.pb.Timestamps()
 			if tt.wantErr {
@@ -1138,41 +1036,6 @@ func TestTimestamps(t *testing.T) {
 			}
 			require.NoError(t, gotErr)
 			require.Equal(t, tt.wantTimestamps, got)
-		})
-	}
-}
-
-func TestNewBundleWithAllowCertificateChain(t *testing.T) {
-	t.Parallel()
-
-	v03BundleWithCertChain := &protobundle.Bundle{
-		MediaType: "application/vnd.dev.sigstore.bundle.v0.3+json",
-		VerificationMaterial: &protobundle.VerificationMaterial{
-			Content: &protobundle.VerificationMaterial_X509CertificateChain{
-				X509CertificateChain: &protocommon.X509CertificateChain{},
-			},
-		},
-		Content: &protobundle.Bundle_MessageSignature{},
-	}
-
-	for _, tc := range []struct {
-		name    string
-		opts    []Option
-		wantErr bool
-	}{
-		{"v0.3 with cert chain without option", nil, true},
-		{"v0.3 with cert chain with AllowCertificateChain", []Option{AllowCertificateChain()}, false},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			bundle, err := NewBundle(v03BundleWithCertChain, tc.opts...)
-			if tc.wantErr {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "verification material cannot be X.509 certificate chain")
-			} else {
-				require.NoError(t, err)
-				require.NotNil(t, bundle)
-			}
 		})
 	}
 }
@@ -1292,5 +1155,152 @@ func TestTlogEntriesCountAtCap(t *testing.T) {
 	_, err := b.TlogEntries()
 	if err != nil {
 		require.NotContains(t, err.Error(), "too many tlog entries")
+	}
+}
+
+func TestNewBundleWithAllowCertificateChain(t *testing.T) {
+	t.Parallel()
+
+	v03BundleWithCertChain := &protobundle.Bundle{
+		MediaType: "application/vnd.dev.sigstore.bundle.v0.3+json",
+		VerificationMaterial: &protobundle.VerificationMaterial{
+			Content: &protobundle.VerificationMaterial_X509CertificateChain{
+				X509CertificateChain: &protocommon.X509CertificateChain{},
+			},
+		},
+		Content: &protobundle.Bundle_MessageSignature{},
+	}
+
+	for _, tc := range []struct {
+		name    string
+		opts    []Option
+		wantErr bool
+	}{
+		{"v0.3 with cert chain without option", nil, true},
+		{"v0.3 with cert chain with AllowCertificateChain", []Option{AllowCertificateChain()}, false},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			bundle, err := NewBundle(v03BundleWithCertChain, tc.opts...)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "verification material cannot be X.509 certificate chain")
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, bundle)
+			}
+		})
+	}
+}
+
+func TestIntermediateContent(t *testing.T) {
+	t.Parallel()
+	rootKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	intermediateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	leafKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	rootCert := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	intermediateCert := &x509.Certificate{
+		SerialNumber:          big.NewInt(2),
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	leafCert := &x509.Certificate{SerialNumber: big.NewInt(3)}
+
+	rootDer, err := x509.CreateCertificate(rand.Reader, rootCert, rootCert, &rootKey.PublicKey, rootKey)
+	require.NoError(t, err)
+	intermediateDer, err := x509.CreateCertificate(rand.Reader, intermediateCert, rootCert, &intermediateKey.PublicKey, rootKey)
+	require.NoError(t, err)
+	leafDer, err := x509.CreateCertificate(rand.Reader, leafCert, intermediateCert, &leafKey.PublicKey, intermediateKey)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		b         Bundle
+		wantCount int
+	}{
+		{
+			name:      "nil verification material",
+			b:         Bundle{Bundle: &protobundle.Bundle{}},
+			wantCount: 0,
+		},
+		{
+			name: "single certificate (not a chain)",
+			b: Bundle{Bundle: &protobundle.Bundle{
+				VerificationMaterial: &protobundle.VerificationMaterial{
+					Content: &protobundle.VerificationMaterial_Certificate{
+						Certificate: &protocommon.X509Certificate{RawBytes: leafDer},
+					},
+				},
+			}},
+			wantCount: 0,
+		},
+		{
+			name: "chain with only leaf",
+			b: Bundle{Bundle: &protobundle.Bundle{
+				VerificationMaterial: &protobundle.VerificationMaterial{
+					Content: &protobundle.VerificationMaterial_X509CertificateChain{
+						X509CertificateChain: &protocommon.X509CertificateChain{
+							Certificates: []*protocommon.X509Certificate{
+								{RawBytes: leafDer},
+							},
+						},
+					},
+				},
+			}},
+			wantCount: 0,
+		},
+		{
+			name: "chain with leaf and intermediate",
+			b: Bundle{Bundle: &protobundle.Bundle{
+				VerificationMaterial: &protobundle.VerificationMaterial{
+					Content: &protobundle.VerificationMaterial_X509CertificateChain{
+						X509CertificateChain: &protocommon.X509CertificateChain{
+							Certificates: []*protocommon.X509Certificate{
+								{RawBytes: leafDer},
+								{RawBytes: intermediateDer},
+							},
+						},
+					},
+				},
+			}},
+			wantCount: 1,
+		},
+		{
+			name: "chain with leaf, intermediate, and root",
+			b: Bundle{Bundle: &protobundle.Bundle{
+				VerificationMaterial: &protobundle.VerificationMaterial{
+					Content: &protobundle.VerificationMaterial_X509CertificateChain{
+						X509CertificateChain: &protocommon.X509CertificateChain{
+							Certificates: []*protocommon.X509Certificate{
+								{RawBytes: leafDer},
+								{RawBytes: intermediateDer},
+								{RawBytes: rootDer},
+							},
+						},
+					},
+				},
+			}},
+			wantCount: 2,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.b.IntermediateContent()
+			require.Len(t, got, tt.wantCount)
+			for _, cert := range got {
+				require.True(t, cert.IsCA)
+			}
+		})
 	}
 }

--- a/pkg/bundle/bundle_test.go
+++ b/pkg/bundle/bundle_test.go
@@ -1033,6 +1033,42 @@ func TestTimestamps(t *testing.T) {
 	}
 }
 
+func TestNewBundleWithAllowCertificateChain(t *testing.T) {
+	t.Parallel()
+
+	v03BundleWithCertChain := &protobundle.Bundle{
+		MediaType: "application/vnd.dev.sigstore.bundle.v0.3+json",
+		VerificationMaterial: &protobundle.VerificationMaterial{
+			Content: &protobundle.VerificationMaterial_X509CertificateChain{
+				X509CertificateChain: &protocommon.X509CertificateChain{},
+			},
+		},
+		Content: &protobundle.Bundle_MessageSignature{},
+	}
+
+	for _, tc := range []struct {
+		name    string
+		opts    []Option
+		wantErr bool
+	}{
+		{"v0.3 with cert chain without option", nil, true},
+		{"v0.3 with cert chain with AllowCertificateChain", []Option{AllowCertificateChain()}, false},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			bundle, err := NewBundle(v03BundleWithCertChain, tc.opts...)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "verification material cannot be X.509 certificate chain")
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, bundle)
+			}
+		})
+	}
+}
+
 func Test_BundleValidation(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/pkg/bundle/bundle_test.go
+++ b/pkg/bundle/bundle_test.go
@@ -559,7 +559,6 @@ func Test_validate(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.pb.validate()
 			if (got != nil) != tt.wantErr {
@@ -807,7 +806,6 @@ func TestVerificationContent(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got, gotErr := tt.pb.VerificationContent()
 			if tt.wantErr {
@@ -894,7 +892,6 @@ func TestSignatureContent(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got, gotErr := tt.pb.SignatureContent()
 			if tt.wantErr {
@@ -949,7 +946,6 @@ func TestEnvelope(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			_, gotErr := tt.pb.Envelope()
 			if tt.wantErr {
@@ -1027,7 +1023,6 @@ func TestTimestamps(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got, gotErr := tt.pb.Timestamps()
 			if tt.wantErr {
@@ -1292,8 +1287,8 @@ func TestIntermediateContent(t *testing.T) {
 			wantCount: 2,
 		},
 	}
+
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := tt.b.IntermediateContent()

--- a/pkg/bundle/bundle_test.go
+++ b/pkg/bundle/bundle_test.go
@@ -127,7 +127,6 @@ func TestMinVersion(t *testing.T) {
 		{"blank", "", "", false},
 		{"invalid", "garbage", "v0.1", false},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			b := &Bundle{Bundle: &protobundle.Bundle{
@@ -155,7 +154,6 @@ func TestMediaTypeString(t *testing.T) {
 		{"blank", "", "", true},
 		{"invalid", "garbage", "", true},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			res, err := MediaTypeString(tc.ver)
@@ -1174,7 +1172,6 @@ func TestNewBundleWithAllowCertificateChain(t *testing.T) {
 		{"v0.3 with cert chain without option", nil, true},
 		{"v0.3 with cert chain with AllowCertificateChain", []Option{AllowCertificateChain()}, false},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			bundle, err := NewBundle(v03BundleWithCertChain, tc.opts...)
@@ -1195,6 +1192,8 @@ func TestVerificationContentIntermediates(t *testing.T) {
 	require.NoError(t, err)
 	intermediateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
+	subordinateIntermediateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
 	leafKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
 
@@ -1208,34 +1207,43 @@ func TestVerificationContentIntermediates(t *testing.T) {
 		BasicConstraintsValid: true,
 		IsCA:                  true,
 	}
-	leafCert := &x509.Certificate{SerialNumber: big.NewInt(3)}
+	subordinateIntermediateCert := &x509.Certificate{
+		SerialNumber:          big.NewInt(3),
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	leafCert := &x509.Certificate{SerialNumber: big.NewInt(4)}
 
 	rootDer, err := x509.CreateCertificate(rand.Reader, rootCert, rootCert, &rootKey.PublicKey, rootKey)
 	require.NoError(t, err)
 	intermediateDer, err := x509.CreateCertificate(rand.Reader, intermediateCert, rootCert, &intermediateKey.PublicKey, rootKey)
 	require.NoError(t, err)
-	leafDer, err := x509.CreateCertificate(rand.Reader, leafCert, intermediateCert, &leafKey.PublicKey, intermediateKey)
+	subordinateIntermediateDer, err := x509.CreateCertificate(rand.Reader, subordinateIntermediateCert, intermediateCert, &subordinateIntermediateKey.PublicKey, intermediateKey)
+	require.NoError(t, err)
+	leafDer, err := x509.CreateCertificate(rand.Reader, leafCert, subordinateIntermediateCert, &leafKey.PublicKey, subordinateIntermediateKey)
 	require.NoError(t, err)
 
 	tests := []struct {
-		name      string
-		b         Bundle
-		wantCount int
+		name                  string
+		bundle                Bundle
+		allowCertificateChain bool
+		wantSerials           []*big.Int
 	}{
 		{
-			name: "single certificate (not a chain)",
-			b: Bundle{Bundle: &protobundle.Bundle{
+			name: "single certificate verification material",
+			bundle: Bundle{Bundle: &protobundle.Bundle{
 				VerificationMaterial: &protobundle.VerificationMaterial{
 					Content: &protobundle.VerificationMaterial_Certificate{
 						Certificate: &protocommon.X509Certificate{RawBytes: leafDer},
 					},
 				},
 			}},
-			wantCount: 0,
+			allowCertificateChain: true,
+			wantSerials:           nil,
 		},
 		{
-			name: "chain with only leaf",
-			b: Bundle{Bundle: &protobundle.Bundle{
+			name: "certificate chain with leaf only",
+			bundle: Bundle{Bundle: &protobundle.Bundle{
 				VerificationMaterial: &protobundle.VerificationMaterial{
 					Content: &protobundle.VerificationMaterial_X509CertificateChain{
 						X509CertificateChain: &protocommon.X509CertificateChain{
@@ -1246,52 +1254,93 @@ func TestVerificationContentIntermediates(t *testing.T) {
 					},
 				},
 			}},
-			wantCount: 0,
+			allowCertificateChain: true,
+			wantSerials:           nil,
 		},
 		{
-			name: "chain with leaf and intermediate",
-			b: Bundle{Bundle: &protobundle.Bundle{
+			name: "certificate chain with leaf and intermediate",
+			bundle: Bundle{Bundle: &protobundle.Bundle{
 				VerificationMaterial: &protobundle.VerificationMaterial{
 					Content: &protobundle.VerificationMaterial_X509CertificateChain{
 						X509CertificateChain: &protocommon.X509CertificateChain{
 							Certificates: []*protocommon.X509Certificate{
 								{RawBytes: leafDer},
+								{RawBytes: subordinateIntermediateDer},
+							},
+						},
+					},
+				},
+			}},
+			allowCertificateChain: true,
+			wantSerials:           []*big.Int{subordinateIntermediateCert.SerialNumber},
+		},
+		{
+			name: "certificate chain with leaf and multiple intermediates",
+			bundle: Bundle{Bundle: &protobundle.Bundle{
+				VerificationMaterial: &protobundle.VerificationMaterial{
+					Content: &protobundle.VerificationMaterial_X509CertificateChain{
+						X509CertificateChain: &protocommon.X509CertificateChain{
+							Certificates: []*protocommon.X509Certificate{
+								{RawBytes: leafDer},
+								{RawBytes: subordinateIntermediateDer},
 								{RawBytes: intermediateDer},
 							},
 						},
 					},
 				},
 			}},
-			wantCount: 1,
+			allowCertificateChain: true,
+			wantSerials:           []*big.Int{subordinateIntermediateCert.SerialNumber, intermediateCert.SerialNumber},
 		},
 		{
-			name: "chain with leaf, intermediate, and root",
-			b: Bundle{Bundle: &protobundle.Bundle{
+			name: "certificate chain with intermediate but certificate chain option disabled",
+			bundle: Bundle{Bundle: &protobundle.Bundle{
 				VerificationMaterial: &protobundle.VerificationMaterial{
 					Content: &protobundle.VerificationMaterial_X509CertificateChain{
 						X509CertificateChain: &protocommon.X509CertificateChain{
 							Certificates: []*protocommon.X509Certificate{
 								{RawBytes: leafDer},
-								{RawBytes: intermediateDer},
+								{RawBytes: subordinateIntermediateDer},
+							},
+						},
+					},
+				},
+			}},
+			allowCertificateChain: false,
+			wantSerials:           nil,
+		},
+		{
+			// https://github.com/sigstore/protobuf-specs/blob/4a31a816c74309e66a4c037c7e20f2500a588f8a/protos/sigstore_bundle.proto#L75-L79
+			name: "certificate chain with leaf, intermediate, and root ignores the root",
+			bundle: Bundle{Bundle: &protobundle.Bundle{
+				VerificationMaterial: &protobundle.VerificationMaterial{
+					Content: &protobundle.VerificationMaterial_X509CertificateChain{
+						X509CertificateChain: &protocommon.X509CertificateChain{
+							Certificates: []*protocommon.X509Certificate{
+								{RawBytes: leafDer},
+								{RawBytes: subordinateIntermediateDer},
 								{RawBytes: rootDer},
 							},
 						},
 					},
 				},
 			}},
-			wantCount: 2,
+			allowCertificateChain: true,
+			wantSerials:           []*big.Int{subordinateIntermediateCert.SerialNumber},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			vc, err := tt.b.VerificationContent()
+			tt.bundle.allowCertificateChain = tt.allowCertificateChain
+			vc, err := tt.bundle.VerificationContent()
 			require.NoError(t, err)
 			got := vc.Intermediates()
-			require.Len(t, got, tt.wantCount)
-			for _, cert := range got {
+			require.Len(t, got, len(tt.wantSerials))
+			for i, cert := range got {
 				require.True(t, cert.IsCA)
+				require.Equal(t, tt.wantSerials[i], cert.SerialNumber)
 			}
 		})
 	}
@@ -1305,19 +1354,22 @@ func TestVerificationContentIntermediatesParseError(t *testing.T) {
 	leafDer, err := x509.CreateCertificate(rand.Reader, leafTmpl, leafTmpl, &leafKey.PublicKey, leafKey)
 	require.NoError(t, err)
 
-	b := Bundle{Bundle: &protobundle.Bundle{
-		VerificationMaterial: &protobundle.VerificationMaterial{
-			Content: &protobundle.VerificationMaterial_X509CertificateChain{
-				X509CertificateChain: &protocommon.X509CertificateChain{
-					Certificates: []*protocommon.X509Certificate{
-						{RawBytes: leafDer},
-						{RawBytes: []byte("not a certificate")},
+	bundle := Bundle{
+		Bundle: &protobundle.Bundle{
+			VerificationMaterial: &protobundle.VerificationMaterial{
+				Content: &protobundle.VerificationMaterial_X509CertificateChain{
+					X509CertificateChain: &protocommon.X509CertificateChain{
+						Certificates: []*protocommon.X509Certificate{
+							{RawBytes: leafDer},
+							{RawBytes: []byte("not a certificate")},
+						},
 					},
 				},
 			},
 		},
-	}}
-	_, err = b.VerificationContent()
+		allowCertificateChain: true,
+	}
+	_, err = bundle.VerificationContent()
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrValidation)
 }

--- a/pkg/bundle/bundle_test.go
+++ b/pkg/bundle/bundle_test.go
@@ -566,21 +566,130 @@ func Test_validate(t *testing.T) {
 	}
 }
 
-func TestVerificationContent(t *testing.T) {
-	t.Parallel()
-	caCert := &x509.Certificate{
-		SerialNumber: big.NewInt(1),
-	}
-	leafCert := &x509.Certificate{
-		SerialNumber: big.NewInt(2),
-	}
-	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+func createTestCertChain(t *testing.T) (rootDer, intermediateDer, leafDer []byte) {
+	t.Helper()
+	rootKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	intermediateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
 	leafKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
-	caDer, err := x509.CreateCertificate(rand.Reader, caCert, caCert, &caKey.PublicKey, caKey)
+
+	rootCert := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	intermediateCert := &x509.Certificate{
+		SerialNumber:          big.NewInt(2),
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	leafCertTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(3),
+	}
+
+	rootDer, err = x509.CreateCertificate(rand.Reader, rootCert, rootCert, &rootKey.PublicKey, rootKey)
 	require.NoError(t, err)
-	leafDer, err := x509.CreateCertificate(rand.Reader, leafCert, caCert, &leafKey.PublicKey, caKey)
+	intermediateDer, err = x509.CreateCertificate(rand.Reader, intermediateCert, rootCert, &intermediateKey.PublicKey, rootKey)
+	require.NoError(t, err)
+	leafDer, err = x509.CreateCertificate(rand.Reader, leafCertTmpl, intermediateCert, &leafKey.PublicKey, intermediateKey)
+	require.NoError(t, err)
+	return
+}
+
+func TestIntermediateCertificateAuthorities(t *testing.T) {
+	t.Parallel()
+	rootDer, intermediateDer, leafDer := createTestCertChain(t)
+	tests := []struct {
+		name      string
+		b         Bundle
+		wantCount int
+	}{
+		{
+			name:      "nil verification material",
+			b:         Bundle{Bundle: &protobundle.Bundle{}},
+			wantCount: 0,
+		},
+		{
+			name: "single certificate (no chain)",
+			b: Bundle{Bundle: &protobundle.Bundle{
+				VerificationMaterial: &protobundle.VerificationMaterial{
+					Content: &protobundle.VerificationMaterial_Certificate{
+						Certificate: &protocommon.X509Certificate{RawBytes: leafDer},
+					},
+				},
+			}},
+			wantCount: 0,
+		},
+		{
+			name: "chain with leaf and intermediate",
+			b: Bundle{Bundle: &protobundle.Bundle{
+				VerificationMaterial: &protobundle.VerificationMaterial{
+					Content: &protobundle.VerificationMaterial_X509CertificateChain{
+						X509CertificateChain: &protocommon.X509CertificateChain{
+							Certificates: []*protocommon.X509Certificate{
+								{RawBytes: leafDer},
+								{RawBytes: intermediateDer},
+							},
+						},
+					},
+				},
+			}},
+			wantCount: 1,
+		},
+		{
+			name: "chain with leaf intermediate and root",
+			b: Bundle{Bundle: &protobundle.Bundle{
+				VerificationMaterial: &protobundle.VerificationMaterial{
+					Content: &protobundle.VerificationMaterial_X509CertificateChain{
+						X509CertificateChain: &protocommon.X509CertificateChain{
+							Certificates: []*protocommon.X509Certificate{
+								{RawBytes: leafDer},
+								{RawBytes: intermediateDer},
+								{RawBytes: rootDer},
+							},
+						},
+					},
+				},
+			}},
+			wantCount: 2,
+		},
+		{
+			name: "chain with only leaf",
+			b: Bundle{Bundle: &protobundle.Bundle{
+				VerificationMaterial: &protobundle.VerificationMaterial{
+					Content: &protobundle.VerificationMaterial_X509CertificateChain{
+						X509CertificateChain: &protocommon.X509CertificateChain{
+							Certificates: []*protocommon.X509Certificate{
+								{RawBytes: leafDer},
+							},
+						},
+					},
+				},
+			}},
+			wantCount: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.b.IntermediateContent()
+			require.Len(t, got, tt.wantCount)
+			for _, cert := range got {
+				require.True(t, cert.IsCA)
+			}
+		})
+	}
+}
+
+func TestVerificationContent(t *testing.T) {
+	t.Parallel()
+	_, _, leafDer := createTestCertChain(t)
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	caCert := &x509.Certificate{SerialNumber: big.NewInt(100)}
+	caDer, err := x509.CreateCertificate(rand.Reader, caCert, caCert, &caKey.PublicKey, caKey)
 	require.NoError(t, err)
 	tests := []struct {
 		name            string
@@ -1054,7 +1163,6 @@ func TestNewBundleWithAllowCertificateChain(t *testing.T) {
 		{"v0.3 with cert chain without option", nil, true},
 		{"v0.3 with cert chain with AllowCertificateChain", []Option{AllowCertificateChain()}, false},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			bundle, err := NewBundle(v03BundleWithCertChain, tc.opts...)

--- a/pkg/bundle/bundle_test.go
+++ b/pkg/bundle/bundle_test.go
@@ -1228,6 +1228,8 @@ func TestVerificationContentIntermediates(t *testing.T) {
 		bundle                Bundle
 		allowCertificateChain bool
 		wantSerials           []*big.Int
+		wantErr               bool
+		wantErrContains       string
 	}{
 		{
 			name: "single certificate verification material",
@@ -1310,9 +1312,9 @@ func TestVerificationContentIntermediates(t *testing.T) {
 			wantSerials:           nil,
 		},
 		{
-			// https://github.com/sigstore/protobuf-specs/blob/4a31a816c74309e66a4c037c7e20f2500a588f8a/protos/sigstore_bundle.proto#L75-L79
-			name: "certificate chain with leaf, intermediate, and root ignores the root",
+			name: "certificate chain with leaf, intermediate, and self-signed root is rejected",
 			bundle: Bundle{Bundle: &protobundle.Bundle{
+				MediaType: "application/vnd.dev.sigstore.bundle.v0.3+json",
 				VerificationMaterial: &protobundle.VerificationMaterial{
 					Content: &protobundle.VerificationMaterial_X509CertificateChain{
 						X509CertificateChain: &protocommon.X509CertificateChain{
@@ -1326,7 +1328,8 @@ func TestVerificationContentIntermediates(t *testing.T) {
 				},
 			}},
 			allowCertificateChain: true,
-			wantSerials:           []*big.Int{subordinateIntermediateCert.SerialNumber},
+			wantErr:               true,
+			wantErrContains:       "self-signed certificate found in certificate chain",
 		},
 	}
 
@@ -1335,6 +1338,13 @@ func TestVerificationContentIntermediates(t *testing.T) {
 			t.Parallel()
 			tt.bundle.allowCertificateChain = tt.allowCertificateChain
 			vc, err := tt.bundle.VerificationContent()
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.wantErrContains != "" {
+					require.ErrorContains(t, err, tt.wantErrContains)
+				}
+				return
+			}
 			require.NoError(t, err)
 			got := vc.Intermediates()
 			require.Len(t, got, len(tt.wantSerials))

--- a/pkg/bundle/options.go
+++ b/pkg/bundle/options.go
@@ -1,0 +1,27 @@
+// Copyright 2023 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bundle
+
+// BundleOption configures optional behaviour when constructing a Bundle.
+type BundleOption func(*Bundle)
+
+// AllowCertificateChain permits bundles with version >= v0.3 to contain
+// X.509 certificate chains in their verification material. By default,
+// v0.3+ bundles require a single certificate rather than a chain.
+func AllowCertificateChain() BundleOption {
+	return func(b *Bundle) {
+		b.allowCertificateChain = true
+	}
+}

--- a/pkg/bundle/options.go
+++ b/pkg/bundle/options.go
@@ -14,13 +14,13 @@
 
 package bundle
 
-// BundleOption configures optional behaviour when constructing a Bundle.
-type BundleOption func(*Bundle)
+// Option configures optional behaviour when constructing a Bundle.
+type Option func(*Bundle)
 
 // AllowCertificateChain permits bundles with version >= v0.3 to contain
 // X.509 certificate chains in their verification material. By default,
 // v0.3+ bundles require a single certificate rather than a chain.
-func AllowCertificateChain() BundleOption {
+func AllowCertificateChain() Option {
 	return func(b *Bundle) {
 		b.allowCertificateChain = true
 	}

--- a/pkg/bundle/verification_content.go
+++ b/pkg/bundle/verification_content.go
@@ -24,7 +24,8 @@ import (
 )
 
 type Certificate struct {
-	certificate *x509.Certificate
+	certificate   *x509.Certificate
+	intermediates []*x509.Certificate
 }
 
 func NewCertificate(cert *x509.Certificate) *Certificate {
@@ -56,6 +57,10 @@ func (c *Certificate) Certificate() *x509.Certificate {
 	return c.certificate
 }
 
+func (c *Certificate) Intermediates() []*x509.Certificate {
+	return c.intermediates
+}
+
 func (c *Certificate) PublicKey() verify.PublicKeyProvider {
 	return nil
 }
@@ -84,6 +89,10 @@ func (pk *PublicKey) ValidAtTime(t time.Time, tm root.TrustedMaterial) bool {
 }
 
 func (pk *PublicKey) Certificate() *x509.Certificate {
+	return nil
+}
+
+func (pk *PublicKey) Intermediates() []*x509.Certificate {
 	return nil
 }
 

--- a/pkg/sign/certificate.go
+++ b/pkg/sign/certificate.go
@@ -42,6 +42,10 @@ type CertificateProvider interface {
 	GetCertificate(context.Context, Keypair, *CertificateProviderOptions) ([]byte, error)
 }
 
+type CertificateChainProvider interface {
+	GetCertificateChain(context.Context, Keypair, *CertificateProviderOptions) ([][]byte, error)
+}
+
 type Fulcio struct {
 	options *FulcioOptions
 	client  *http.Client

--- a/pkg/sign/signer.go
+++ b/pkg/sign/signer.go
@@ -78,7 +78,8 @@ func Bundle(content Content, keypair Keypair, opts BundleOptions) (*protobundle.
 
 	// Add verification information to bundle
 	var verifierPEM []byte
-	if opts.CertificateChainProvider != nil {
+	switch {
+	case opts.CertificateChainProvider != nil:
 		certificateChain, err := opts.CertificateChainProvider.GetCertificateChain(opts.Context, keypair, opts.CertificateProviderOptions)
 		if err != nil {
 			return nil, err
@@ -103,7 +104,7 @@ func Bundle(content Content, keypair Keypair, opts BundleOptions) (*protobundle.
 			Type:  "CERTIFICATE",
 			Bytes: certificateChain[0],
 		})
-	} else if opts.CertificateProvider != nil {
+	case opts.CertificateProvider != nil:
 		pubKeyBytes, err := opts.CertificateProvider.GetCertificate(opts.Context, keypair, opts.CertificateProviderOptions)
 		if err != nil {
 			return nil, err
@@ -121,7 +122,7 @@ func Bundle(content Content, keypair Keypair, opts BundleOptions) (*protobundle.
 			Type:  "CERTIFICATE",
 			Bytes: pubKeyBytes,
 		})
-	} else {
+	default:
 		bundle.VerificationMaterial = &protobundle.VerificationMaterial{
 			Content: &protobundle.VerificationMaterial_PublicKey{
 				PublicKey: &protocommon.PublicKeyIdentifier{

--- a/pkg/sign/signer.go
+++ b/pkg/sign/signer.go
@@ -17,6 +17,7 @@ package sign
 import (
 	"bytes"
 	"context"
+	"crypto/x509"
 	"encoding/pem"
 	"errors"
 
@@ -89,7 +90,17 @@ func Bundle(content Content, keypair Keypair, opts BundleOptions) (*protobundle.
 		}
 
 		certificateChainProto := &protocommon.X509CertificateChain{}
-		for _, certBytes := range certificateChain {
+		certificateChainProto.Certificates = append(certificateChainProto.Certificates, &protocommon.X509Certificate{
+			RawBytes: certificateChain[0],
+		})
+		for _, certBytes := range certificateChain[1:] {
+			parsed, err := x509.ParseCertificate(certBytes)
+			if err != nil {
+				return nil, err
+			}
+			if verify.IsSelfSigned(parsed) {
+				return nil, errors.New("certificate chain must not contain a self-signed (root) certificate")
+			}
 			certificateChainProto.Certificates = append(certificateChainProto.Certificates, &protocommon.X509Certificate{
 				RawBytes: certBytes,
 			})

--- a/pkg/sign/signer.go
+++ b/pkg/sign/signer.go
@@ -36,6 +36,10 @@ type BundleOptions struct {
 	// Typically a Fulcio instance; resulting bundle will contain a certificate
 	// for its verification material content instead of a public key.
 	CertificateProvider CertificateProvider
+	// Optional certificate chain provider for private Fulcio deployments
+	// with Intermediate CAs. Takes precedence over CertificateProvider
+	// and stores a full X509CertificateChain in the bundle.
+	CertificateChainProvider CertificateChainProvider
 	// Optional options for certificate provider
 	//
 	// Some certificate authorities may require options to be set
@@ -74,7 +78,32 @@ func Bundle(content Content, keypair Keypair, opts BundleOptions) (*protobundle.
 
 	// Add verification information to bundle
 	var verifierPEM []byte
-	if opts.CertificateProvider != nil {
+	if opts.CertificateChainProvider != nil {
+		certificateChain, err := opts.CertificateChainProvider.GetCertificateChain(opts.Context, keypair, opts.CertificateProviderOptions)
+		if err != nil {
+			return nil, err
+		}
+		if len(certificateChain) == 0 {
+			return nil, errors.New("certificates provider returned no certificates")
+		}
+
+		certificateChainProto := &protocommon.X509CertificateChain{}
+		for _, certBytes := range certificateChain {
+			certificateChainProto.Certificates = append(certificateChainProto.Certificates, &protocommon.X509Certificate{
+				RawBytes: certBytes,
+			})
+		}
+		bundle.VerificationMaterial = &protobundle.VerificationMaterial{
+			Content: &protobundle.VerificationMaterial_X509CertificateChain{
+				X509CertificateChain: certificateChainProto,
+			},
+		}
+
+		verifierPEM = pem.EncodeToMemory(&pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: certificateChain[0],
+		})
+	} else if opts.CertificateProvider != nil {
 		pubKeyBytes, err := opts.CertificateProvider.GetCertificate(opts.Context, keypair, opts.CertificateProviderOptions)
 		if err != nil {
 			return nil, err
@@ -139,7 +168,7 @@ func Bundle(content Content, keypair Keypair, opts BundleOptions) (*protobundle.
 		// Verification will fail if a timestamp authority is not provided for Rekor v2.
 		if len(opts.TimestampAuthorities) == 0 {
 			// Only use the Rekor integrated timestamp if there's a certificate, otherwise don't require time
-			if opts.CertificateProvider != nil {
+			if opts.CertificateProvider != nil || opts.CertificateChainProvider != nil {
 				verifierOptions = append(verifierOptions, verify.WithIntegratedTimestamps(len(opts.TransparencyLogs)))
 			} else {
 				verifierOptions = append(verifierOptions, verify.WithNoObserverTimestamps())
@@ -150,7 +179,7 @@ func Bundle(content Content, keypair Keypair, opts BundleOptions) (*protobundle.
 	// A time verification policy must be provided. If no signed timestamp or integrated timestamp was
 	// retrieved, verify a certificate with the current time or don't verify time for a key
 	if len(opts.TimestampAuthorities) == 0 && len(opts.TransparencyLogs) == 0 {
-		if opts.CertificateProvider != nil {
+		if opts.CertificateProvider != nil || opts.CertificateChainProvider != nil {
 			verifierOptions = append(verifierOptions, verify.WithCurrentTime())
 		} else {
 			verifierOptions = append(verifierOptions, verify.WithNoObserverTimestamps())
@@ -163,7 +192,11 @@ func Bundle(content Content, keypair Keypair, opts BundleOptions) (*protobundle.
 			return nil, err
 		}
 
-		protobundle, err := verifyBundle.NewBundle(bundle)
+		var bundleOpts []verifyBundle.Option
+		if opts.CertificateChainProvider != nil {
+			bundleOpts = append(bundleOpts, verifyBundle.AllowCertificateChain())
+		}
+		protobundle, err := verifyBundle.NewBundle(bundle, bundleOpts...)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sign/signer.go
+++ b/pkg/sign/signer.go
@@ -24,6 +24,7 @@ import (
 	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
 	protocommon "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
 
+	"github.com/sigstore/sigstore-go/internal/certificate"
 	verifyBundle "github.com/sigstore/sigstore-go/pkg/bundle"
 	"github.com/sigstore/sigstore-go/pkg/root"
 	"github.com/sigstore/sigstore-go/pkg/verify"
@@ -98,7 +99,7 @@ func Bundle(content Content, keypair Keypair, opts BundleOptions) (*protobundle.
 			if err != nil {
 				return nil, err
 			}
-			if verify.IsSelfSigned(parsed) {
+			if certificate.IsSelfSigned(parsed) {
 				return nil, errors.New("certificate chain must not contain a self-signed (root) certificate")
 			}
 			certificateChainProto.Certificates = append(certificateChainProto.Certificates, &protocommon.X509Certificate{

--- a/pkg/verify/certificate.go
+++ b/pkg/verify/certificate.go
@@ -31,7 +31,8 @@ func verifyLeafCertificate(observerTimestamp time.Time, leafCert *x509.Certifica
 		caToVerify := ca
 		if fca, ok := ca.(*root.FulcioCertificateAuthority); ok && len(intermediates) > 0 {
 			withIntermediates := *fca
-			withIntermediates.Intermediates = append(fca.Intermediates, intermediates...)
+			withIntermediates.Intermediates = append([]*x509.Certificate{}, fca.Intermediates...)
+			withIntermediates.Intermediates = append(withIntermediates.Intermediates, intermediates...)
 			caToVerify = &withIntermediates
 		}
 		chains, err := caToVerify.Verify(leafCert, observerTimestamp)

--- a/pkg/verify/certificate.go
+++ b/pkg/verify/certificate.go
@@ -15,6 +15,7 @@
 package verify
 
 import (
+	"bytes"
 	"crypto/x509"
 	"errors"
 	"time"
@@ -28,18 +29,24 @@ func VerifyLeafCertificate(observerTimestamp time.Time, leafCert *x509.Certifica
 
 func verifyLeafCertificate(observerTimestamp time.Time, leafCert *x509.Certificate, trustedMaterial root.TrustedMaterial, intermediates []*x509.Certificate) ([][]*x509.Certificate, error) {
 	for _, ca := range trustedMaterial.FulcioCertificateAuthorities() {
-		caToVerify := ca
 		if fca, ok := ca.(*root.FulcioCertificateAuthority); ok && len(intermediates) > 0 {
 			withIntermediates := *fca
 			withIntermediates.Intermediates = append([]*x509.Certificate{}, fca.Intermediates...)
 			withIntermediates.Intermediates = append(withIntermediates.Intermediates, intermediates...)
-			caToVerify = &withIntermediates
+			ca = &withIntermediates
 		}
-		chains, err := caToVerify.Verify(leafCert, observerTimestamp)
+		chains, err := ca.Verify(leafCert, observerTimestamp)
 		if err == nil {
 			return chains, nil
 		}
 	}
 
 	return nil, errors.New("leaf certificate verification failed")
+}
+
+func IsSelfSigned(certificate *x509.Certificate) bool {
+	if !bytes.Equal(certificate.RawSubject, certificate.RawIssuer) {
+		return false
+	}
+	return certificate.CheckSignatureFrom(certificate) == nil
 }

--- a/pkg/verify/certificate.go
+++ b/pkg/verify/certificate.go
@@ -23,8 +23,18 @@ import (
 )
 
 func VerifyLeafCertificate(observerTimestamp time.Time, leafCert *x509.Certificate, trustedMaterial root.TrustedMaterial) ([][]*x509.Certificate, error) { // nolint: revive
+	return verifyLeafCertificate(observerTimestamp, leafCert, trustedMaterial, nil)
+}
+
+func verifyLeafCertificate(observerTimestamp time.Time, leafCert *x509.Certificate, trustedMaterial root.TrustedMaterial, intermediates []*x509.Certificate) ([][]*x509.Certificate, error) {
 	for _, ca := range trustedMaterial.FulcioCertificateAuthorities() {
-		chains, err := ca.Verify(leafCert, observerTimestamp)
+		caToVerify := ca
+		if fca, ok := ca.(*root.FulcioCertificateAuthority); ok && len(intermediates) > 0 {
+			withIntermediates := *fca
+			withIntermediates.Intermediates = append(fca.Intermediates, intermediates...)
+			caToVerify = &withIntermediates
+		}
+		chains, err := caToVerify.Verify(leafCert, observerTimestamp)
 		if err == nil {
 			return chains, nil
 		}

--- a/pkg/verify/certificate.go
+++ b/pkg/verify/certificate.go
@@ -15,7 +15,6 @@
 package verify
 
 import (
-	"bytes"
 	"crypto/x509"
 	"errors"
 	"time"
@@ -42,11 +41,4 @@ func verifyLeafCertificate(observerTimestamp time.Time, leafCert *x509.Certifica
 	}
 
 	return nil, errors.New("leaf certificate verification failed")
-}
-
-func IsSelfSigned(certificate *x509.Certificate) bool {
-	if !bytes.Equal(certificate.RawSubject, certificate.RawIssuer) {
-		return false
-	}
-	return certificate.CheckSignatureFrom(certificate) == nil
 }

--- a/pkg/verify/certificate_test.go
+++ b/pkg/verify/certificate_test.go
@@ -18,10 +18,60 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sigstore/sigstore-go/pkg/root"
 	"github.com/sigstore/sigstore-go/pkg/testing/ca"
 	"github.com/sigstore/sigstore-go/pkg/verify"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestVerifyLeafCertificateWithIntermediateCertificateAuthorities(t *testing.T) {
+	virtualSigstore, err := ca.NewVirtualSigstore()
+	assert.NoError(t, err)
+
+	leaf, _, err := virtualSigstore.GenerateLeafCert("example@example.com", "issuer")
+	assert.NoError(t, err)
+
+	cas := virtualSigstore.FulcioCertificateAuthorities()
+	assert.Greater(t, len(cas), 0)
+	fca := cas[0].(*root.FulcioCertificateAuthority)
+
+	strippedCA := *fca
+	strippedCA.Intermediates = nil
+
+	tests := []struct {
+		name    string
+		ca      *root.FulcioCertificateAuthority
+		wantErr bool
+	}{
+		{
+			name:    "full CA verifies",
+			ca:      fca,
+			wantErr: false,
+		},
+		{
+			name:    "stripped CA fails",
+			ca:      &strippedCA,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.ca.Verify(leaf, time.Now())
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+
+	// Verify that adding intermediates back to a stripped CA fixes verification.
+	// This is the path exercised when a bundle provides intermediate certificate authorities.
+	restoredCA := strippedCA
+	restoredCA.Intermediates = fca.Intermediates
+	_, err = restoredCA.Verify(leaf, time.Now())
+	assert.NoError(t, err)
+}
 
 func TestVerifyValidityPeriod(t *testing.T) {
 	virtualSigstore, err := ca.NewVirtualSigstore()

--- a/pkg/verify/certificate_test.go
+++ b/pkg/verify/certificate_test.go
@@ -18,60 +18,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sigstore/sigstore-go/pkg/root"
 	"github.com/sigstore/sigstore-go/pkg/testing/ca"
 	"github.com/sigstore/sigstore-go/pkg/verify"
 	"github.com/stretchr/testify/assert"
 )
-
-func TestVerifyLeafCertificateWithIntermediateCertificateAuthorities(t *testing.T) {
-	virtualSigstore, err := ca.NewVirtualSigstore()
-	assert.NoError(t, err)
-
-	leaf, _, err := virtualSigstore.GenerateLeafCert("example@example.com", "issuer")
-	assert.NoError(t, err)
-
-	cas := virtualSigstore.FulcioCertificateAuthorities()
-	assert.Greater(t, len(cas), 0)
-	fca := cas[0].(*root.FulcioCertificateAuthority)
-
-	strippedCA := *fca
-	strippedCA.Intermediates = nil
-
-	tests := []struct {
-		name    string
-		ca      *root.FulcioCertificateAuthority
-		wantErr bool
-	}{
-		{
-			name:    "full CA verifies",
-			ca:      fca,
-			wantErr: false,
-		},
-		{
-			name:    "stripped CA fails",
-			ca:      &strippedCA,
-			wantErr: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			_, err := tt.ca.Verify(leaf, time.Now())
-			if tt.wantErr {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-			}
-		})
-	}
-
-	// Verify that adding intermediates back to a stripped CA fixes verification.
-	// This is the path exercised when a bundle provides intermediate certificate authorities.
-	restoredCA := strippedCA
-	restoredCA.Intermediates = fca.Intermediates
-	_, err = restoredCA.Verify(leaf, time.Now())
-	assert.NoError(t, err)
-}
 
 func TestVerifyValidityPeriod(t *testing.T) {
 	virtualSigstore, err := ca.NewVirtualSigstore()

--- a/pkg/verify/interface.go
+++ b/pkg/verify/interface.go
@@ -65,17 +65,11 @@ type SignedEntity interface {
 	VersionProvider
 }
 
-// IntermediateCAProvider is an optional interface a SignedEntity can implement
-// to supply Intermediate CA certificates for path validation. Used for private
-// Fulcio deployments where the bundle carries an X509CertificateChain.
-type IntermediateCAProvider interface {
-	IntermediateContent() []*x509.Certificate
-}
-
 type VerificationContent interface {
 	CompareKey(any, root.TrustedMaterial) bool
 	ValidAtTime(time.Time, root.TrustedMaterial) bool
 	Certificate() *x509.Certificate
+	Intermediates() []*x509.Certificate
 	PublicKey() PublicKeyProvider
 }
 

--- a/pkg/verify/interface.go
+++ b/pkg/verify/interface.go
@@ -65,6 +65,13 @@ type SignedEntity interface {
 	VersionProvider
 }
 
+// IntermediateCAProvider is an optional interface a SignedEntity can implement
+// to supply Intermediate CA certificates for path validation. Used for private
+// Fulcio deployments where the bundle carries an X509CertificateChain.
+type IntermediateCAProvider interface {
+	IntermediateContent() []*x509.Certificate
+}
+
 type VerificationContent interface {
 	CompareKey(any, root.TrustedMaterial) bool
 	ValidAtTime(time.Time, root.TrustedMaterial) bool

--- a/pkg/verify/signed_entity.go
+++ b/pkg/verify/signed_entity.go
@@ -665,10 +665,7 @@ func (v *Verifier) Verify(entity SignedEntity, pb PolicyBuilder) (*VerificationR
 
 		// If the bundle verification material contains an X509CertificateChain,
 		// extract the Intermediate CA certificates to use during certificate path validation.
-		var intermediates []*x509.Certificate
-		if cip, ok := entity.(IntermediateCAProvider); ok {
-			intermediates = cip.IntermediateContent()
-		}
+		intermediates := verificationContent.Intermediates()
 
 		var chains [][]*x509.Certificate
 		for _, verifiedTs := range verifiedTimestamps {

--- a/pkg/verify/signed_entity.go
+++ b/pkg/verify/signed_entity.go
@@ -663,10 +663,16 @@ func (v *Verifier) Verify(entity SignedEntity, pb PolicyBuilder) (*VerificationR
 			leafCert.UnhandledCriticalExtensions = unhandledExts
 		}
 
+		// If the bundle verification material contains an X509CertificateChain,
+		// extract the Intermediate CA certificates to use during certificate path validation.
+		var intermediates []*x509.Certificate
+		if cip, ok := entity.(IntermediateCAProvider); ok {
+			intermediates = cip.IntermediateContent()
+		}
+
 		var chains [][]*x509.Certificate
 		for _, verifiedTs := range verifiedTimestamps {
-			// verify the leaf certificate against the root
-			chains, err = VerifyLeafCertificate(verifiedTs.Timestamp, leafCert, v.trustedMaterial)
+			chains, err = verifyLeafCertificate(verifiedTs.Timestamp, leafCert, v.trustedMaterial, intermediates)
 			if err != nil {
 				return nil, fmt.Errorf("failed to verify leaf certificate: %w", err)
 			}


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

- Within sigstore/cosign we had opened a [thread](https://github.com/sigstore/cosign/pull/4614#issuecomment-3708746997) with @Hayden-IO around supporting OCI Image validation within the v0.3 bundle using certificate chains. 

> So tl;dr - it is fine to include the certificate chain in a v0.3 bundle. If there's any constraints in sigstore-go around parsing v0.3 bundles with chains, we can relax those constraints. Implementing support in Cosign is the intended design - see https://github.com/sigstore/sigstore-go/issues/132 and https://github.com/sigstore/sigstore-go/issues/298 (Edit: also https://github.com/sigstore/sigstore-go/pull/253 for more discussion) for some context, where we discussed an interface that allows us to create verifiers for alternative (aka not Sigstore-spec compliant) signing/verification paths for private deployments.

- For the change in https://github.com/sigstore/cosign/pull/4614 if we attempt to create a v0.3 bundle which includes a certificate chain and verify the OCI Image we get the following error. By adding a configurable `--allow-certificate-chain` flag we load the Intermediate Certificate Authorities that are exist within the Sigstore bundle to establish the Trust Store.

```sh
cosign verify \
    --insecure-ignore-tlog \
    --insecure-ignore-sct \
    --check-claims=true \
    --certificate-identity example.com \
    --certificate-oidc-issuer-regexp ".*" \
    --trusted-root trusted-roots.json \
    --new-bundle-format \
    --use-signed-timestamps \
    --experimental-oci11 \
    {OCI IMAGE}
WARNING: Skipping tlog verification is an insecure practice that lacks transparency and auditability verification for the signature.
Error: no signatures found
error during command execution: no signatures found
```

```sh
cosign verify \
    --insecure-ignore-tlog \
    --insecure-ignore-sct \
    --check-claims=true \
    --certificate-identity example.com \
    --certificate-oidc-issuer-regexp ".*" \
    --trusted-root trusted-roots.json \
    --new-bundle-format \
    --use-signed-timestamps \
    --experimental-oci11 \
    --allow-certificate-chain \
    {OCI IMAGE}

The following checks were performed on each of these signatures:
  - The cosign claims were validated
  - Existence of the claims in the transparency log was verified offline
  - The code-signing certificate was verified using trusted certificate authority certificates
```

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

- NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

- https://docs.sigstore.dev/cosign/signing/signing_with_containers