### PR TITLE
verify message digest matches artifact hash

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -47,10 +47,10 @@ jobs:
       - uses: sigstore/sigstore-conformance@9611941d54398f2e3f6383b6f744442a56d2fb2a # v0.0.26
         with:
           entrypoint: ${{ github.workspace }}/conformance
-          xfail: "test_verify*managed-key-happy-path] test_verify*managed-key-and-trusted-root] test_verify*PATH-message-digest-mismatch_fail]"
+          xfail: "test_verify*managed-key-happy-path] test_verify*managed-key-and-trusted-root]"
 
       - uses: sigstore/sigstore-conformance@9611941d54398f2e3f6383b6f744442a56d2fb2a # v0.0.26
         with:
           entrypoint: ${{ github.workspace }}/conformance
           environment: staging
-          xfail: "test_verify*managed-key-happy-path] test_verify*managed-key-and-trusted-root] test_verify*PATH-message-digest-mismatch_fail]"
+          xfail: "test_verify*managed-key-happy-path] test_verify*managed-key-and-trusted-root]"

--- a/pkg/verify/signature.go
+++ b/pkg/verify/signature.go
@@ -380,12 +380,13 @@ func isDigestInSlice(digest []byte, digestSlice [][]byte) bool {
 }
 
 func verifyMessageSignatureContent(verifier signature.Verifier, msg MessageSignatureContent, artifact io.Reader) error {
+	// Message digest is an unauthenticated hint and MUST NOT be used to verify the signature
 	if msg.Digest() == nil {
 		return errors.New("message is missing artifact digest")
 	}
 	hashFunc, err := algStringToHashFunc(msg.DigestAlgorithm())
 	if err != nil {
-		return fmt.Errorf("could not verify message digest: %w", err)
+		return fmt.Errorf("could not verify message digest algorithm: %w", err)
 	}
 	hasher := hashFunc.New()
 	reader := io.TeeReader(artifact, hasher)
@@ -395,6 +396,7 @@ func verifyMessageSignatureContent(verifier signature.Verifier, msg MessageSigna
 		return fmt.Errorf("could not verify message: %w", err)
 	}
 
+	// Message digest is also checked against actually digest after signature verification as a sanity check
 	if !bytes.Equal(hasher.Sum(nil), msg.Digest()) {
 		return errors.New("artifact digest does not match message digest")
 	}

--- a/pkg/verify/signature.go
+++ b/pkg/verify/signature.go
@@ -83,7 +83,7 @@ func verifySignatureWithVerifierAndArtifacts(verifier signature.Verifier, sigCon
 		if len(artifacts) != 1 {
 			return fmt.Errorf("only one artifact can be verified with a message signature")
 		}
-		return verifyMessageSignature(verifier, msg, artifacts[0])
+		return verifyMessageSignatureContent(verifier, msg, artifacts[0])
 	}
 
 	// Otherwise, verify the envelope with the provided artifacts
@@ -379,10 +379,24 @@ func isDigestInSlice(digest []byte, digestSlice [][]byte) bool {
 	return false
 }
 
-func verifyMessageSignature(verifier signature.Verifier, msg MessageSignatureContent, artifact io.Reader) error {
-	err := verifier.VerifySignature(bytes.NewReader(msg.Signature()), artifact)
+func verifyMessageSignatureContent(verifier signature.Verifier, msg MessageSignatureContent, artifact io.Reader) error {
+	if msg.Digest() == nil {
+		return errors.New("message is missing artifact digest")
+	}
+	hashFunc, err := algStringToHashFunc(msg.DigestAlgorithm())
+	if err != nil {
+		return fmt.Errorf("could not verify message digest: %w", err)
+	}
+	hasher := hashFunc.New()
+	reader := io.TeeReader(artifact, hasher)
+
+	err = verifier.VerifySignature(bytes.NewReader(msg.Signature()), reader)
 	if err != nil {
 		return fmt.Errorf("could not verify message: %w", err)
+	}
+
+	if !bytes.Equal(hasher.Sum(nil), msg.Digest()) {
+		return errors.New("artifact digest does not match message digest")
 	}
 
 	return nil
@@ -449,12 +463,14 @@ func (m *multihasher) Sum(b []byte) map[crypto.Hash][]byte {
 
 func algStringToHashFunc(alg string) (crypto.Hash, error) {
 	switch alg {
-	case "sha256":
+	case "sha256", v1.HashAlgorithm_SHA2_256.String():
 		return crypto.SHA256, nil
-	case "sha384":
+	case "sha384", v1.HashAlgorithm_SHA2_384.String():
 		return crypto.SHA384, nil
-	case "sha512":
+	case "sha512", v1.HashAlgorithm_SHA2_512.String():
 		return crypto.SHA512, nil
+	case "":
+		return 0, errors.New("empty digest algorithm")
 	default:
 		return 0, errors.New("unsupported digest algorithm")
 	}

--- a/pkg/verify/signature_internal_test.go
+++ b/pkg/verify/signature_internal_test.go
@@ -15,12 +15,17 @@
 package verify
 
 import (
+	"bytes"
 	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"crypto/sha256"
 	"crypto/sha512"
 	"testing"
 
 	in_toto "github.com/in-toto/attestation/go/v1"
+	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -152,6 +157,100 @@ func TestGetHashFunctions(t *testing.T) {
 				assert.NoError(t, err)
 			}
 			assert.Equal(t, test.expectOutput, hfs)
+		})
+	}
+}
+
+// testMessageSignatureContent is a mock for testing verifyMessageSignatureContent directly.
+type testMessageSignatureContent struct {
+	digest          []byte
+	digestAlgorithm string
+	signature       []byte
+}
+
+func (t *testMessageSignatureContent) Digest() []byte          { return t.digest }
+func (t *testMessageSignatureContent) DigestAlgorithm() string { return t.digestAlgorithm }
+func (t *testMessageSignatureContent) Signature() []byte       { return t.signature }
+
+func TestVerifyMessageDigest(t *testing.T) {
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	assert.NoError(t, err)
+	signer, err := signature.LoadECDSASignerVerifier(privKey, crypto.SHA256)
+	assert.NoError(t, err)
+
+	artifact := []byte("test artifact")
+	artifactDigest256 := sha256.Sum256(artifact)
+	artifactDigest384 := sha512.Sum384(artifact)
+	artifactDigest512 := sha512.Sum512(artifact)
+	wrongDigest := sha256.Sum256([]byte("wrong digest"))
+
+	sig, err := signer.SignMessage(bytes.NewReader(artifact))
+	assert.NoError(t, err)
+
+	for _, tc := range []struct {
+		name            string
+		digest          []byte
+		digestAlgorithm string
+		expectErr       string
+	}{
+		{
+			name:            "matching digest passes - 256",
+			digest:          artifactDigest256[:],
+			digestAlgorithm: "SHA2_256",
+		},
+		{
+			name:            "matching digest passes - 384",
+			digest:          artifactDigest384[:],
+			digestAlgorithm: "SHA2_384",
+		},
+		{
+			name:            "matching digest passes - 512",
+			digest:          artifactDigest512[:],
+			digestAlgorithm: "SHA2_512",
+		},
+		{
+			name:            "mismatched hash algorithm",
+			digest:          artifactDigest256[:],
+			digestAlgorithm: "SHA2_384",
+			expectErr:       "artifact digest does not match message digest",
+		},
+		{
+			name:            "mismatched digest fails",
+			digest:          wrongDigest[:],
+			digestAlgorithm: "SHA2_256",
+			expectErr:       "artifact digest does not match message digest",
+		},
+		{
+			name:            "nil digest returns error",
+			digest:          nil,
+			digestAlgorithm: "SHA2_256",
+			expectErr:       "message is missing artifact digest",
+		},
+		{
+			name:            "empty digest algorithm returns error",
+			digest:          artifactDigest256[:],
+			digestAlgorithm: "",
+			expectErr:       "empty digest algorithm",
+		},
+		{
+			name:            "unsupported digest algorithm returns error",
+			digest:          artifactDigest256[:],
+			digestAlgorithm: "SHA3_256",
+			expectErr:       "unsupported digest algorithm",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := &testMessageSignatureContent{
+				digest:          tc.digest,
+				digestAlgorithm: tc.digestAlgorithm,
+				signature:       sig,
+			}
+			err := verifyMessageSignatureContent(signer, msg, bytes.NewReader(artifact))
+			if tc.expectErr != "" {
+				assert.ErrorContains(t, err, tc.expectErr)
+			} else {
+				assert.NoError(t, err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

Working on https://github.com/sigstore/sigstore-go/issues/561

#### Summary
This change is to address a [new, failing conformance test](https://github.com/sigstore/sigstore-conformance/pull/312).
- Change verifyMessageSignature -> verifyMessageSignatureContent
- Fail if message digest is empty or message digest algorithm is invalid
- Check artifact hash against message digest after verifying signature
- Add testing for supported hash algorithms and mismatched digests
- Remove xfail from conformance test workflow

#### Release Note
- Verification checks the message digest against the artifact has in addition to verifying the message signature. 

#### Documentation
N/A
