### PR TITLE
feat(tuf): Add GetTopLevelTargets to Client API

### DIFF
--- a/pkg/tuf/client.go
+++ b/pkg/tuf/client.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/theupdateframework/go-tuf/v2/metadata"
 	"github.com/theupdateframework/go-tuf/v2/metadata/config"
 	"github.com/theupdateframework/go-tuf/v2/metadata/fetcher"
 	"github.com/theupdateframework/go-tuf/v2/metadata/updater"
@@ -195,6 +196,13 @@ func (c *Client) GetTarget(target string) ([]byte, error) {
 	}
 
 	return tb, nil
+}
+
+// GetTopLevelTargets returns the top-level target files from the TUF
+// repository metadata. This can be used to enumerate available targets
+// and inspect their metadata (e.g. custom fields) without downloading them.
+func (c *Client) GetTopLevelTargets() map[string]*metadata.TargetFiles {
+	return c.up.GetTopLevelTargets()
 }
 
 // URLToPath converts a URL to a filename-compatible string

--- a/pkg/tuf/client_test.go
+++ b/pkg/tuf/client_test.go
@@ -449,6 +449,37 @@ func (r *testRepo) SetTimestamp(date time.Time) {
 	}
 }
 
+func TestGetTopLevelTargets(t *testing.T) {
+	r := newTestRepo(t)
+	r.AddTarget("foo.txt", []byte("foo content"))
+	r.AddTarget("bar.txt", []byte("bar content"))
+	rootJSON, err := r.roles.Root().ToBytes(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var opt = DefaultOptions().
+		WithRepositoryBaseURL("https://testing.local").
+		WithRoot(rootJSON).
+		WithCachePath(t.TempDir()).
+		WithFetcher(r).
+		WithDisableLocalCache()
+	c, err := New(opt)
+	assert.NotNil(t, c)
+	assert.NoError(t, err)
+
+	targets := c.GetTopLevelTargets()
+	assert.Len(t, targets, 2)
+	assert.Contains(t, targets, "foo.txt")
+	assert.Contains(t, targets, "bar.txt")
+
+	// Verify target metadata has expected fields
+	for name, tf := range targets {
+		assert.Greater(t, tf.Length, int64(0), "target %s should have non-zero length", name)
+		assert.NotEmpty(t, tf.Hashes, "target %s should have hashes", name)
+	}
+}
+
 func TestURLToPath(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Summary
- Expose `GetTopLevelTargets()` on the TUF `Client`, delegating to the underlying go-tuf v2 `updater.GetTopLevelTargets()`
- Allows callers to enumerate available targets and inspect their metadata (e.g. custom fields) without downloading them

## Motivation
This is needed to support the migration of [sigstore/policy-controller](https://github.com/sigstore/policy-controller) from go-tuf v1 to v2 (see https://github.com/sigstore/policy-controller/pull/1945).

The policy-controller's TrustRoot reconciler needs to:
1. Check if a `trusted_root.json` target exists in the TUF repository
2. Fall back to scanning custom metadata on individual targets to discover Fulcio, Rekor, and CTLog entries

Currently policy-controller uses go-tuf v2's `updater.Updater` directly. With this addition, it can use the sigstore-go TUF client instead, which provides a cleaner abstraction with built-in caching, user-agent handling, and cache validity management.

## Test plan
- [x] `go test ./pkg/tuf/...` passes
- [x] New test: `TestGetTopLevelTargets` — verifies multiple targets returned with correct metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)