### PR TITLE
Harden verification, HTTP clients, and TUF

### DIFF
--- a/pkg/root/trusted_root.go
+++ b/pkg/root/trusted_root.go
@@ -498,30 +498,41 @@ func NewLiveTrustedRootFromTargetWithPeriod(opts *tuf.Options, target string, rf
 		mu:          sync.RWMutex{},
 	}
 
+	var done <-chan struct{}
+	if opts != nil && opts.Context != nil {
+		done = opts.Context.Done()
+	}
+
 	ticker := time.NewTicker(rfPeriod)
 	go func() {
-		for range ticker.C {
-			client, err = tuf.New(opts)
-			if err != nil {
-				log.Printf("error creating TUF client: %v", err)
-				continue
-			}
+		for {
+			select {
+			case <-done:
+				ticker.Stop()
+				return
+			case <-ticker.C:
+				client, err = tuf.New(opts)
+				if err != nil {
+					log.Printf("error creating TUF client: %v", err)
+					continue
+				}
 
-			b, err := client.GetTarget(target)
-			if err != nil {
-				log.Printf("error fetching trusted root: %v", err)
-				continue
-			}
+				b, err := client.GetTarget(target)
+				if err != nil {
+					log.Printf("error fetching trusted root: %v", err)
+					continue
+				}
 
-			newTr, err := NewTrustedRootFromJSON(b)
-			if err != nil {
-				log.Printf("error fetching trusted root: %v", err)
-				continue
+				newTr, err := NewTrustedRootFromJSON(b)
+				if err != nil {
+					log.Printf("error fetching trusted root: %v", err)
+					continue
+				}
+				ltr.mu.Lock()
+				ltr.TrustedRoot = newTr
+				ltr.mu.Unlock()
+				log.Printf("successfully refreshed the TUF root")
 			}
-			ltr.mu.Lock()
-			ltr.TrustedRoot = newTr
-			ltr.mu.Unlock()
-			log.Printf("successfully refreshed the TUF root")
 		}
 	}()
 	return ltr, nil

--- a/pkg/sign/certificate.go
+++ b/pkg/sign/certificate.go
@@ -190,6 +190,8 @@ func (f *Fulcio) GetCertificate(ctx context.Context, keypair Keypair, opts *Cert
 			break
 		}
 
+		response.Body.Close()
+
 		delay := time.Duration(math.Pow(2, float64(attempts)))
 		timer := time.NewTimer(delay * time.Second)
 		select {
@@ -200,8 +202,11 @@ func (f *Fulcio) GetCertificate(ctx context.Context, keypair Keypair, opts *Cert
 		}
 		attempts++
 	}
+	if response != nil && response.Body != nil {
+		defer response.Body.Close()
+	}
 
-	body, err := io.ReadAll(response.Body)
+	body, err := io.ReadAll(io.LimitReader(response.Body, 1<<20))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sign/timestamping.go
+++ b/pkg/sign/timestamping.go
@@ -97,6 +97,8 @@ func (ta *TimestampAuthority) GetTimestamp(ctx context.Context, signature []byte
 			break
 		}
 
+		response.Body.Close()
+
 		delay := time.Duration(math.Pow(2, float64(attempts)))
 		timer := time.NewTimer(delay * time.Second)
 		select {
@@ -107,8 +109,11 @@ func (ta *TimestampAuthority) GetTimestamp(ctx context.Context, signature []byte
 		}
 		attempts++
 	}
+	if response != nil && response.Body != nil {
+		defer response.Body.Close()
+	}
 
-	body, err := io.ReadAll(response.Body)
+	body, err := io.ReadAll(io.LimitReader(response.Body, 1<<20))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tuf/options.go
+++ b/pkg/tuf/options.go
@@ -15,6 +15,7 @@
 package tuf
 
 import (
+	"context"
 	"embed"
 	"math"
 	"os"
@@ -68,6 +69,14 @@ type Options struct {
 	DisableConsistentSnapshot bool
 	// Fetcher is the metadata fetcher
 	Fetcher fetcher.Fetcher
+	// Context is the context for TUF background tasks
+	Context context.Context
+}
+
+// WithContext sets the context for TUF background tasks
+func (o *Options) WithContext(ctx context.Context) *Options {
+	o.Context = ctx
+	return o
 }
 
 // WithCacheValidity sets the cache validity period in days

--- a/pkg/verify/signature.go
+++ b/pkg/verify/signature.go
@@ -248,6 +248,9 @@ func verifyEnvelope(verifier signature.Verifier, envelope EnvelopeContent) error
 }
 
 func verifyEnvelopeWithArtifacts(verifier signature.Verifier, envelope EnvelopeContent, artifacts []io.Reader) error {
+	if len(artifacts) == 0 {
+		return fmt.Errorf("no artifacts provided for verification")
+	}
 	if err := verifyEnvelope(verifier, envelope); err != nil {
 		return err
 	}
@@ -327,6 +330,9 @@ func verifyEnvelopeWithArtifacts(verifier signature.Verifier, envelope EnvelopeC
 }
 
 func verifyEnvelopeWithArtifactDigests(verifier signature.Verifier, envelope EnvelopeContent, digests []ArtifactDigest) error {
+	if len(digests) == 0 {
+		return fmt.Errorf("no artifact digests provided for verification")
+	}
 	if err := verifyEnvelope(verifier, envelope); err != nil {
 		return err
 	}

--- a/pkg/verify/signature_test.go
+++ b/pkg/verify/signature_test.go
@@ -252,6 +252,12 @@ func TestVerifyEnvelopeWithMultipleArtifactsAndArtifactDigests(t *testing.T) {
 	}
 	_, err = verifier.Verify(entity, verify.NewPolicy(verify.WithArtifactDigests(noMatchingArtifactDigests), verify.WithoutIdentitiesUnsafe()))
 	assert.Error(t, err)
+
+	_, err = verifier.Verify(entity, verify.NewPolicy(verify.WithArtifacts([]io.Reader{}), verify.WithoutIdentitiesUnsafe()))
+	assert.ErrorContains(t, err, "no artifacts provided for verification")
+
+	_, err = verifier.Verify(entity, verify.NewPolicy(verify.WithArtifactDigests([]verify.ArtifactDigest{}), verify.WithoutIdentitiesUnsafe()))
+	assert.ErrorContains(t, err, "no artifact digests provided for verification")
 }
 
 func TestCompatibilityAlgorithms(t *testing.T) {


### PR DESCRIPTION
This proposes a few fixes to the signing and verification paths to prevent memory leaks and skipping verification due to client misconfiguration.

* **pkg/verify:** Prevent artifact verification bypass by explicitly rejecting empty artifact/digest slices during envelope validation.
* **pkg/sign:** Fix memory exhaustion and connection leaks by bounding response reads and closing HTTP connections before retry logic in Fulcio and Timestamping clients.
* **pkg/root:** Resolve permanent goroutine leak in `LiveTrustedRoot` by adding `Context` to `tuf.Options` for graceful background refresh cancellation.

Signed-off-by: Hayden <8418760+Hayden-IO@users.noreply.github.com>
Co-authored-by: Gemini 3.1 Pro