### PR TITLE
Verify log entry digest matches artifact/envelope

### DIFF
--- a/pkg/root/signing_config_test.go
+++ b/pkg/root/signing_config_test.go
@@ -32,7 +32,7 @@ func servicesEqual(got []Service, want []Service) bool {
 		return false
 	}
 	for i, g := range got {
-		w := want[i]
+		w := want[i] //nolint:gosec
 		if g.URL != w.URL || g.MajorAPIVersion != w.MajorAPIVersion ||
 			!g.ValidityPeriodStart.Equal(w.ValidityPeriodStart) ||
 			!g.ValidityPeriodEnd.Equal(w.ValidityPeriodEnd) ||

--- a/pkg/testing/ca/ca.go
+++ b/pkg/testing/ca/ca.go
@@ -43,6 +43,7 @@ import (
 	"github.com/sigstore/rekor/pkg/generated/models"
 	"github.com/sigstore/rekor/pkg/pki"
 	"github.com/sigstore/rekor/pkg/types"
+	dsseEntry "github.com/sigstore/rekor/pkg/types/dsse"
 	"github.com/sigstore/rekor/pkg/types/hashedrekord"
 	"github.com/sigstore/rekor/pkg/types/intoto"
 	"github.com/sigstore/rekor/pkg/types/rekord"
@@ -326,8 +327,7 @@ func (ca *VirtualSigstore) GenerateTlogEntry(leafCert *x509.Certificate, envelop
 	if err != nil {
 		return nil, err
 	}
-
-	rekorBody, err := generateRekorEntry(intoto.KIND, intoto.New().DefaultVersion(), envelopeBytes, leafCertPem, sig, ca.signingAlgorithmDetails)
+	rekorBody, err := generateRekorEntry(dsseEntry.KIND, dsseEntry.New().DefaultVersion(), envelopeBytes, leafCertPem, sig, ca.signingAlgorithmDetails)
 	if err != nil {
 		return nil, err
 	}
@@ -461,7 +461,7 @@ func createEntry(ctx context.Context, kind, apiVersion string, blobBytes, certBy
 		PKIFormat:      string(pki.X509),
 	}
 	switch kind {
-	case rekord.KIND, intoto.KIND:
+	case rekord.KIND, intoto.KIND, dsseEntry.KIND:
 		props.ArtifactBytes = blobBytes
 		props.SignatureBytes = sigBytes
 	case hashedrekord.KIND:

--- a/pkg/tlog/entry.go
+++ b/pkg/tlog/entry.go
@@ -423,6 +423,72 @@ func (entry *Entry) TransparencyLogEntry() *v1.TransparencyLogEntry {
 	return entry.tle
 }
 
+func (entry *Entry) GetHashedRekordDigest() (digest []byte, algorithm string, ok bool) {
+	if entry == nil {
+		return nil, "", false
+	}
+	if entry.rekorV1Entry != nil {
+		if e, ok := entry.rekorV1Entry.(*hashedrekord_v001.V001Entry); ok {
+			if e.HashedRekordObj.Data != nil && e.HashedRekordObj.Data.Hash != nil {
+				hashBytes, err := hex.DecodeString(*e.HashedRekordObj.Data.Hash.Value)
+				if err != nil {
+					return nil, "", false
+				}
+				return hashBytes, *e.HashedRekordObj.Data.Hash.Algorithm, true
+			}
+		}
+	}
+	if entry.rekorV2Entry != nil {
+		spec := entry.rekorV2Entry.GetSpec()
+		if spec != nil {
+			if e, ok := spec.GetSpec().(*rekortilespb.Spec_HashedRekordV002); ok {
+				if e.HashedRekordV002 != nil && e.HashedRekordV002.GetData() != nil {
+					return e.HashedRekordV002.GetData().GetDigest(), e.HashedRekordV002.GetData().GetAlgorithm().String(), true
+				}
+			}
+		}
+	}
+	return nil, "", false
+}
+
+func (entry *Entry) GetDssePayloadHash() (digest []byte, ok bool) {
+	if entry == nil {
+		return nil, false
+	}
+	if entry.rekorV2Entry != nil {
+		spec := entry.rekorV2Entry.GetSpec()
+		if spec != nil {
+			if e, ok := spec.GetSpec().(*rekortilespb.Spec_DsseV002); ok {
+				if e.DsseV002 != nil && e.DsseV002.GetPayloadHash() != nil {
+					return e.DsseV002.GetPayloadHash().Digest, true
+				}
+			}
+		}
+	} else if entry.rekorV1Entry != nil {
+		switch e := entry.rekorV1Entry.(type) {
+		case *dsse_v001.V001Entry:
+			if e.DSSEObj.PayloadHash.Value != nil {
+				hashStr := *e.DSSEObj.PayloadHash.Value
+				hashBytes, err := hex.DecodeString(hashStr)
+				if err != nil {
+					return nil, false
+				}
+				return hashBytes, true
+			}
+		case *intoto_v002.V002Entry:
+			if e.IntotoObj.Content != nil && e.IntotoObj.Content.PayloadHash != nil && e.IntotoObj.Content.PayloadHash.Value != nil {
+				hashStr := *e.IntotoObj.Content.PayloadHash.Value
+				hashBytes, err := hex.DecodeString(hashStr)
+				if err != nil {
+					return nil, false
+				}
+				return hashBytes, true
+			}
+		}
+	}
+	return nil, false
+}
+
 // VerifyInclusion verifies a Rekor v1-style checkpoint and the entry's inclusion in the Rekor v1 log.
 // Prefer verify.VerifyTlogEntry, which also compares the log entry against a provided bundle.
 func VerifyInclusion(entry *Entry, verifier signature.Verifier) error {

--- a/pkg/tlog/entry_test.go
+++ b/pkg/tlog/entry_test.go
@@ -16,11 +16,16 @@ package tlog
 
 import (
 	"bytes"
+	"encoding/hex"
 	"testing"
 
 	protocommon "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
 	v1 "github.com/sigstore/protobuf-specs/gen/pb-go/rekor/v1"
 	rekortilespb "github.com/sigstore/rekor-tiles/v2/pkg/generated/protobuf"
+	"github.com/sigstore/rekor/pkg/generated/models"
+	dsse_v001 "github.com/sigstore/rekor/pkg/types/dsse/v0.0.1"
+	hashedrekord_v001 "github.com/sigstore/rekor/pkg/types/hashedrekord/v0.0.1"
+	intoto_v002 "github.com/sigstore/rekor/pkg/types/intoto/v0.0.2"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -317,6 +322,15 @@ func TestUnmarshalRekorV2EntryRejectsWrongApiVersionForEntryType(t *testing.T) {
 	assert.ErrorIs(t, err, ErrInvalidRekorV2Entry)
 }
 
+func TestUnmarshalRekorV2EntryWithEmptyBody(t *testing.T) {
+	var body = []byte("{}")
+
+	re, err := unmarshalRekorV2Entry(body)
+
+	assert.Error(t, err)
+	assert.Nil(t, re)
+}
+
 func TestValidateEntryRejectsRekorV2WhenSpecIsUnset(t *testing.T) {
 	entry := &Entry{
 		rekorV2Entry: &rekortilespb.Entry{
@@ -328,4 +342,199 @@ func TestValidateEntryRejectsRekorV2WhenSpecIsUnset(t *testing.T) {
 
 	err := ValidateEntry(entry)
 	assert.Error(t, err)
+}
+
+func TestGetDssePayloadHash(t *testing.T) {
+	payloadHash := []byte("dummy payload hash")
+	payloadHashHex := hex.EncodeToString(payloadHash)
+
+	tests := []struct {
+		name       string
+		entry      *Entry
+		wantDigest []byte
+		wantOk     bool
+	}{
+		{
+			name: "dsse 0.0.2",
+			entry: &Entry{
+				rekorV2Entry: &rekortilespb.Entry{
+					Spec: &rekortilespb.Spec{
+						Spec: &rekortilespb.Spec_DsseV002{
+							DsseV002: &rekortilespb.DSSELogEntryV002{
+								PayloadHash: &protocommon.HashOutput{
+									Digest: payloadHash,
+								},
+							},
+						},
+					},
+				},
+			},
+			wantDigest: payloadHash,
+			wantOk:     true,
+		},
+		{
+			name: "dsse 0.0.1",
+			entry: &Entry{
+				rekorV1Entry: &dsse_v001.V001Entry{
+					DSSEObj: models.DSSEV001Schema{
+						PayloadHash: &models.DSSEV001SchemaPayloadHash{
+							Value: &payloadHashHex,
+						},
+					},
+				},
+			},
+			wantDigest: payloadHash,
+			wantOk:     true,
+		},
+		{
+			name: "intoto 0.0.2",
+			entry: &Entry{
+				rekorV1Entry: &intoto_v002.V002Entry{
+					IntotoObj: models.IntotoV002Schema{
+						Content: &models.IntotoV002SchemaContent{
+							PayloadHash: &models.IntotoV002SchemaContentPayloadHash{
+								Value: &payloadHashHex,
+							},
+						},
+					},
+				},
+			},
+			wantDigest: payloadHash,
+			wantOk:     true,
+		},
+		{
+			name:       "Nil Entry",
+			entry:      &Entry{},
+			wantDigest: nil,
+			wantOk:     false,
+		},
+		{
+			name: "V2 DSSE Nil Spec",
+			entry: &Entry{
+				rekorV2Entry: &rekortilespb.Entry{},
+			},
+			wantDigest: nil,
+			wantOk:     false,
+		},
+		{
+			name:       "Nil Receiver",
+			entry:      nil,
+			wantDigest: nil,
+			wantOk:     false,
+		},
+		{
+			name: "V2 DSSE Empty Spec",
+			entry: &Entry{
+				rekorV2Entry: &rekortilespb.Entry{
+					Spec: &rekortilespb.Spec{},
+				},
+			},
+			wantDigest: nil,
+			wantOk:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			digest, ok := tt.entry.GetDssePayloadHash()
+			assert.Equal(t, tt.wantOk, ok)
+			assert.Equal(t, tt.wantDigest, digest)
+		})
+	}
+}
+
+func TestGetHashedRekordDigest(t *testing.T) {
+	digest := []byte("dummy digest")
+	digestHex := hex.EncodeToString(digest)
+	algo := "sha256"
+
+	tests := []struct {
+		name          string
+		entry         *Entry
+		wantDigest    []byte
+		wantAlgorithm string
+		wantOk        bool
+	}{
+		{
+			name: "hashedrekord 0.0.1",
+			entry: &Entry{
+				rekorV1Entry: &hashedrekord_v001.V001Entry{
+					HashedRekordObj: models.HashedrekordV001Schema{
+						Data: &models.HashedrekordV001SchemaData{
+							Hash: &models.HashedrekordV001SchemaDataHash{
+								Value:     &digestHex,
+								Algorithm: &algo,
+							},
+						},
+					},
+				},
+			},
+			wantDigest:    digest,
+			wantAlgorithm: algo,
+			wantOk:        true,
+		},
+		{
+			name: "hashedrekord 0.0.2",
+			entry: &Entry{
+				rekorV2Entry: &rekortilespb.Entry{
+					Spec: &rekortilespb.Spec{
+						Spec: &rekortilespb.Spec_HashedRekordV002{
+							HashedRekordV002: &rekortilespb.HashedRekordLogEntryV002{
+								Data: &protocommon.HashOutput{
+									Digest:    digest,
+									Algorithm: protocommon.HashAlgorithm_SHA2_256,
+								},
+							},
+						},
+					},
+				},
+			},
+			wantDigest:    digest,
+			wantAlgorithm: "SHA2_256",
+			wantOk:        true,
+		},
+		{
+			name: "V2 HashedRekord Nil Spec",
+			entry: &Entry{
+				rekorV2Entry: &rekortilespb.Entry{},
+			},
+			wantDigest:    nil,
+			wantAlgorithm: "",
+			wantOk:        false,
+		},
+		{
+			name:          "Nil Receiver",
+			entry:         nil,
+			wantDigest:    nil,
+			wantAlgorithm: "",
+			wantOk:        false,
+		},
+		{
+			name: "V2 HashedRekord Empty Spec",
+			entry: &Entry{
+				rekorV2Entry: &rekortilespb.Entry{
+					Spec: &rekortilespb.Spec{},
+				},
+			},
+			wantDigest:    nil,
+			wantAlgorithm: "",
+			wantOk:        false,
+		},
+		{
+			name:          "Nil Entry",
+			entry:         &Entry{},
+			wantDigest:    nil,
+			wantAlgorithm: "",
+			wantOk:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotDigest, gotAlgo, ok := tt.entry.GetHashedRekordDigest()
+			assert.Equal(t, tt.wantOk, ok)
+			assert.Equal(t, tt.wantAlgorithm, gotAlgo)
+			assert.Equal(t, tt.wantDigest, gotDigest)
+		})
+	}
 }

--- a/pkg/verify/tlog.go
+++ b/pkg/verify/tlog.go
@@ -17,6 +17,8 @@ package verify
 import (
 	"bytes"
 	"crypto"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -136,7 +138,53 @@ func VerifyTlogEntry(entity SignedEntity, trustedMaterial root.TrustedMaterial, 
 			return nil, errors.New("transparency log certificate does not match")
 		}
 
-		// TODO: if you have access to artifact, check that it matches body subject
+		// Ensure that the digest/payload in the bundle matches the tlog entry
+		switch {
+		case sigContent.MessageSignatureContent() != nil:
+			// This message digest must be compared to the provided artifact
+			msgSig := sigContent.MessageSignatureContent()
+			entityDigest := msgSig.Digest()
+			entityAlgo := msgSig.DigestAlgorithm()
+
+			entryDigest, entryAlgo, ok := entry.GetHashedRekordDigest()
+			if !ok {
+				return nil, errors.New("transparency log entry is not a hashedrekord or missing digest")
+			}
+			entityHashFunc, err := algStringToHashFunc(entityAlgo)
+			if err != nil {
+				return nil, err
+			}
+			entryHashFunc, err := algStringToHashFunc(entryAlgo)
+			if err != nil {
+				return nil, err
+			}
+			if entityHashFunc != entryHashFunc {
+				return nil, fmt.Errorf("transparency log hashedrekord entry digest algorithm mismatch: %s != %s", entityAlgo, entryAlgo)
+			}
+			if !bytes.Equal(entityDigest, entryDigest) {
+				return nil, fmt.Errorf("transparency log hashedrekord entry digest %s does not match artifact %s", hex.EncodeToString(entryDigest), hex.EncodeToString(entityDigest))
+			}
+		case sigContent.EnvelopeContent() != nil:
+			envContent := sigContent.EnvelopeContent()
+			env := envContent.RawEnvelope()
+			if env == nil {
+				return nil, errors.New("bundle envelope is missing")
+			}
+			payloadBytes, err := base64.StdEncoding.DecodeString(env.Payload)
+			if err != nil {
+				return nil, fmt.Errorf("failed to decode envelope payload: %w", err)
+			}
+			payloadHash := sha256.Sum256(payloadBytes) // SHA256 is hardcoded in Rekor v1 and v2 for payload hash
+			entryDigest, ok := entry.GetDssePayloadHash()
+			if !ok {
+				return nil, errors.New("transparency log entry is not a dsse or intoto entry or missing payload hash")
+			}
+			if !bytes.Equal(payloadHash[:], entryDigest) {
+				return nil, fmt.Errorf("transparency log dsse/intoto entry payload hash %s does not match envelope payload hash %s", hex.EncodeToString(payloadHash[:]), hex.EncodeToString(entryDigest))
+			}
+		default:
+			return nil, errors.New("bundle must contain either a message signature or an envelope")
+		}
 
 		// Check tlog entry time against bundle certificates
 		if !entry.IntegratedTime().IsZero() {

--- a/pkg/verify/tlog_test.go
+++ b/pkg/verify/tlog_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/secure-systems-lab/go-securesystemslib/dsse"
 	"github.com/sigstore/sigstore-go/pkg/root"
 	"github.com/sigstore/sigstore-go/pkg/testing/ca"
 	"github.com/sigstore/sigstore-go/pkg/tlog"
@@ -247,4 +248,117 @@ func TestInclusionProofAuditPath(t *testing.T) {
 
 	_, err = verify.VerifyTlogEntry(entity, virtualSigstore, 1, true)
 	assert.NoError(t, err)
+}
+
+func TestTlogEntryDigestMismatch(t *testing.T) {
+	virtualSigstore, err := ca.NewVirtualSigstore()
+	assert.NoError(t, err)
+
+	artifact := []byte("hello world")
+	entity, err := virtualSigstore.Sign("foo@example.com", "issuer", artifact)
+	assert.NoError(t, err)
+
+	// Verify should succeed normally
+	_, err = verify.VerifyTlogEntry(entity, virtualSigstore, 1, true)
+	assert.NoError(t, err)
+
+	// Now create an entity with mismatching digest
+	fakeDigest := strings.Repeat("a", 32) // 32 bytes for sha256
+	mismatchEntity := &mismatchDigestEntity{TestEntity: entity, fakeDigest: []byte(fakeDigest)}
+	_, err = verify.VerifyTlogEntry(mismatchEntity, virtualSigstore, 1, true)
+	assert.ErrorContains(t, err, "does not match artifact")
+}
+
+type mismatchDigestEntity struct {
+	*ca.TestEntity
+	fakeDigest []byte
+}
+
+func (e *mismatchDigestEntity) SignatureContent() (verify.SignatureContent, error) {
+	sigContent, err := e.TestEntity.SignatureContent()
+	if err != nil {
+		return nil, err
+	}
+	return &mismatchSignatureContent{sigContent, e.fakeDigest}, nil
+}
+
+type mismatchSignatureContent struct {
+	verify.SignatureContent
+	fakeDigest []byte
+}
+
+func (c *mismatchSignatureContent) MessageSignatureContent() verify.MessageSignatureContent {
+	msgSig := c.SignatureContent.MessageSignatureContent()
+	if msgSig == nil {
+		return nil
+	}
+	return &mismatchMessageSignatureContent{msgSig, c.fakeDigest}
+}
+
+type mismatchMessageSignatureContent struct {
+	verify.MessageSignatureContent
+	fakeDigest []byte
+}
+
+func (c *mismatchMessageSignatureContent) Digest() []byte {
+	return c.fakeDigest
+}
+
+func TestTlogEntryDssePayloadHashMismatch(t *testing.T) {
+	virtualSigstore, err := ca.NewVirtualSigstore()
+	assert.NoError(t, err)
+
+	statement := []byte(`{"_type":"https://in-toto.io/Statement/v0.1","predicateType":"customFoo","subject":[],"predicate":{}}`)
+	entity, err := virtualSigstore.Attest("foo@example.com", "issuer", statement)
+	assert.NoError(t, err)
+
+	// Verify should succeed normally
+	_, err = verify.VerifyTlogEntry(entity, virtualSigstore, 1, true)
+	assert.NoError(t, err)
+
+	// Now create an entity with mismatching envelope payload
+	mismatchEntity := &mismatchEnvelopeEntity{TestEntity: entity}
+	_, err = verify.VerifyTlogEntry(mismatchEntity, virtualSigstore, 1, true)
+	assert.ErrorContains(t, err, "does not match envelope payload hash")
+}
+
+type mismatchEnvelopeEntity struct {
+	*ca.TestEntity
+}
+
+func (e *mismatchEnvelopeEntity) SignatureContent() (verify.SignatureContent, error) {
+	sigContent, err := e.TestEntity.SignatureContent()
+	if err != nil {
+		return nil, err
+	}
+	return &mismatchEnvelopeSignatureContent{sigContent}, nil
+}
+
+type mismatchEnvelopeSignatureContent struct {
+	verify.SignatureContent
+}
+
+func (c *mismatchEnvelopeSignatureContent) EnvelopeContent() verify.EnvelopeContent {
+	envContent := c.SignatureContent.EnvelopeContent()
+	if envContent == nil {
+		return nil
+	}
+	return &mismatchEnvelopeContentWrapper{envContent}
+}
+
+type mismatchEnvelopeContentWrapper struct {
+	verify.EnvelopeContent
+}
+
+func (c *mismatchEnvelopeContentWrapper) RawEnvelope() *dsse.Envelope {
+	env := c.EnvelopeContent.RawEnvelope()
+	if env == nil {
+		return nil
+	}
+	clone := &dsse.Envelope{
+		Payload:     base64.StdEncoding.EncodeToString([]byte("fake payload")),
+		PayloadType: env.PayloadType,
+		Signatures:  env.Signatures,
+	}
+	return clone
 }


### PR DESCRIPTION
A log entry is composed of an artifact hash, signature, and verifier (public key or certificate). When verifying an inclusion proof, we currently pass the canonicalized body to the inclusion proof verifier, where it uses the digest of the canonicalized body as the leaf hash. We must then verify the canonicalized body matches the provided verification material.

We can either recompute the canonicalized body using the artifact hash, signature, and verifier, or we can compare each component individually. That's what's done here - currently, we are comparing the verifier and signature. Comparing the artifact hash is not absolutely necessary because the signature should bind the entry to the artifact, but it shouldn't be assumed that signatures are unique due to malleability.

This PR adds the comparison of the artifact hash. For hashedrekord entries, we compare the digest from the bundle - note that this is marked as an unauthenticated hint, but we now compare it to the provided artifact as part of SignedEntity verification. For dsse/intoto entries we verify only the payload hash, because the envelope hash is over uncanonicalized JSON (and the envelope hash was dropped in Rekor v2).

Arguably, the proper fix is to reconstruct the leaf hash from the artifact, signature and verifier, ignoring the canonicalized body entirely. However, we currently pass the canonicalized body to the inclusion proof verifier, so I didn't want to make a larger change to that library as well at the moment. It would also likely mean a refactoring in sigstore-go with method changes for exported functions.

Fixes #177

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->