### PR TITLE
Encode Rekor v2 DSSE envelopes as hashedrekord

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -44,12 +44,12 @@ jobs:
 
       - run: go build -o conformance test/conformance/main.go
 
-      - uses: sigstore/sigstore-conformance@4d66ba3cb0c9c95f705c757c0f5e226d3f4d5151 # v0.0.27
+      - uses: sigstore/sigstore-conformance@21533cde107c734ebc153c3e3a24d75fc9811a36 # non-release commit that includes hashedrekord dsse test bundles
         with:
           entrypoint: ${{ github.workspace }}/conformance
           xfail: "test_verify*managed-key-happy-path] test_verify*managed-key-and-trusted-root]"
 
-      - uses: sigstore/sigstore-conformance@4d66ba3cb0c9c95f705c757c0f5e226d3f4d5151 # v0.0.27
+      - uses: sigstore/sigstore-conformance@21533cde107c734ebc153c3e3a24d75fc9811a36 # non-release commit that includes hashedrekord dsse test bundles
         with:
           entrypoint: ${{ github.workspace }}/conformance
           environment: staging

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -44,12 +44,12 @@ jobs:
 
       - run: go build -o conformance test/conformance/main.go
 
-      - uses: sigstore/sigstore-conformance@21533cde107c734ebc153c3e3a24d75fc9811a36 # non-release commit that includes hashedrekord dsse test bundles
+      - uses: sigstore/sigstore-conformance@v0.0.29
         with:
           entrypoint: ${{ github.workspace }}/conformance
           xfail: "test_verify*managed-key-happy-path] test_verify*managed-key-and-trusted-root]"
 
-      - uses: sigstore/sigstore-conformance@21533cde107c734ebc153c3e3a24d75fc9811a36 # non-release commit that includes hashedrekord dsse test bundles
+      - uses: sigstore/sigstore-conformance@v0.0.29
         with:
           entrypoint: ${{ github.workspace }}/conformance
           environment: staging

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,8 @@ require (
 	github.com/sigstore/timestamp-authority/v2 v2.0.6
 	github.com/stretchr/testify v1.11.1
 	github.com/theupdateframework/go-tuf/v2 v2.4.2-0.20260407074541-7e8f69f906ef
+	github.com/transparency-dev/formats v0.1.0
+	github.com/transparency-dev/merkle v0.0.2
 	golang.org/x/crypto v0.50.0
 	golang.org/x/mod v0.36.0
 	google.golang.org/protobuf v1.36.11
@@ -73,8 +75,6 @@ require (
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/theupdateframework/go-tuf v0.7.0 // indirect
 	github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399 // indirect
-	github.com/transparency-dev/formats v0.1.0 // indirect
-	github.com/transparency-dev/merkle v0.0.2 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.43.0 // indirect

--- a/pkg/sign/transparency.go
+++ b/pkg/sign/transparency.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"time"
 
+	ssldsse "github.com/secure-systems-lab/go-securesystemslib/dsse"
 	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
 	protocommon "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
 	protorekor "github.com/sigstore/protobuf-specs/gen/pb-go/rekor/v1"
@@ -149,10 +150,10 @@ func (r *Rekor) getRekorV2TLE(ctx context.Context, keyOrCertPEM []byte, b *proto
 		return nil, fmt.Errorf("unknown key type: %s", block.Type)
 	}
 	var opts []signature.LoadOption
-	// When signing with ed25519, only the prehash variant is supported for hashedrekord
-	if messageSignature != nil {
-		opts = append(opts, options.WithED25519ph())
-	}
+	// hashedrekord (used for both message_signature and DSSE envelopes on
+	// Rekor v2) requires a prehashing signature algorithm; ed25519 must use
+	// the prehash variant. This is a no-op for ECDSA/RSA.
+	opts = append(opts, options.WithED25519ph())
 	algoDetails, err := signature.GetDefaultAlgorithmDetails(pubKey, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("getting algorithm details: %w", err)
@@ -176,9 +177,25 @@ func (r *Rekor) getRekorV2TLE(ctx context.Context, keyOrCertPEM []byte, b *proto
 	var req any
 	switch {
 	case dsseEnvelope != nil:
-		req = &rekortilespb.DSSERequestV002{
-			Envelope:  dsseEnvelope,
-			Verifiers: []*rekortilespb.Verifier{verifier},
+		// Rekor v2 only supports hashedrekord entries, so DSSE envelopes are
+		// always uploaded as a hashedrekord whose digest covers the envelope's
+		// PAE. The hash function matches the signing algorithm (e.g.
+		// ECDSA P-256 → SHA-256, P-384 → SHA-384).
+		if len(dsseEnvelope.Signatures) == 0 {
+			return nil, fmt.Errorf("dsse envelope has no signatures")
+		}
+		hf := algoDetails.GetHashType()
+		if hf == crypto.Hash(0) {
+			return nil, fmt.Errorf("hashedrekord entries require a prehashing signature algorithm; for ed25519 keys use ed25519ph")
+		}
+		hasher := hf.New()
+		hasher.Write(ssldsse.PAE(dsseEnvelope.PayloadType, dsseEnvelope.Payload))
+		req = &rekortilespb.HashedRekordRequestV002{
+			Signature: &rekortilespb.Signature{
+				Content:  dsseEnvelope.Signatures[0].Sig,
+				Verifier: verifier,
+			},
+			Digest: hasher.Sum(nil),
 		}
 	case messageSignature != nil:
 		req = &rekortilespb.HashedRekordRequestV002{

--- a/pkg/testing/ca/ca.go
+++ b/pkg/testing/ca/ca.go
@@ -354,17 +354,12 @@ func (ca *VirtualSigstore) generateTlogEntryHashedRekordV2(leafCert *x509.Certif
 	if err != nil {
 		return nil, fmt.Errorf("marshaling rekor v2 entry: %w", err)
 	}
-	// Mirror the server-side pipeline (rekor-tiles internal/server/service.go):
-	// protojson.Marshal -> jsoncanonicalizer.Transform. Without canonicalizing,
-	// the leaf the verifier reconstructs from the bundle won't match this
-	// test fixture.
+	// Canonicalize to match the server-side pipeline.
 	body, err := jsoncanonicalizer.Transform(serialized)
 	if err != nil {
 		return nil, fmt.Errorf("canonicalizing rekor v2 entry: %w", err)
 	}
 
-	// Single-leaf tree: log index 0, tree size 1, root hash == leaf hash,
-	// no sibling hashes needed.
 	leafHash := rfc6962.DefaultHasher.HashLeaf(body)
 	rekorLogs := ca.RekorLogs()
 	rekorLogID, err := getLogID(ca.rekorKey.Public())

--- a/pkg/testing/ca/ca.go
+++ b/pkg/testing/ca/ca.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"crypto"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
@@ -31,6 +32,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"net/url"
 	"strings"
 	"time"
 
@@ -40,6 +42,9 @@ import (
 	"github.com/go-openapi/swag/conv"
 	"github.com/secure-systems-lab/go-securesystemslib/dsse"
 	v1 "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
+	protorekor "github.com/sigstore/protobuf-specs/gen/pb-go/rekor/v1"
+	rekortilespb "github.com/sigstore/rekor-tiles/v2/pkg/generated/protobuf"
+	rekornote "github.com/sigstore/rekor-tiles/v2/pkg/note"
 	"github.com/sigstore/rekor/pkg/generated/models"
 	"github.com/sigstore/rekor/pkg/pki"
 	"github.com/sigstore/rekor/pkg/types"
@@ -56,6 +61,10 @@ import (
 	"github.com/sigstore/sigstore/pkg/signature"
 	sigdsse "github.com/sigstore/sigstore/pkg/signature/dsse"
 	tsx509 "github.com/sigstore/timestamp-authority/v2/pkg/x509"
+	f_log "github.com/transparency-dev/formats/log"
+	"github.com/transparency-dev/merkle/rfc6962"
+	"golang.org/x/mod/sumdb/note"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 type VirtualSigstore struct {
@@ -192,6 +201,8 @@ func (ca *VirtualSigstore) GenerateLeafCert(identity, issuer string) (*x509.Cert
 			return nil, nil, err
 		}
 		privKey, err = rsa.GenerateKey(rand.Reader, int(keySize))
+	case signature.ED25519:
+		_, privKey, err = ed25519.GenerateKey(rand.Reader)
 	}
 	if err != nil {
 		return nil, nil, err
@@ -254,6 +265,161 @@ func (ca *VirtualSigstore) AttestAtTime(identity, issuer string, envelopeBody []
 		envelope:    envelope,
 		tlogEntries: []*tlog.Entry{entry},
 	}, nil
+}
+
+// AttestHashedRekordV2 produces an attestation TestEntity with a Rekor v2 hashedrekord tlog entry.
+func (ca *VirtualSigstore) AttestHashedRekordV2(identity, issuer string, envelopeBody []byte) (*TestEntity, error) {
+	return ca.AttestAtTimeHashedRekordV2(identity, issuer, envelopeBody, time.Now().Add(5*time.Minute))
+}
+
+func (ca *VirtualSigstore) AttestAtTimeHashedRekordV2(identity, issuer string, envelopeBody []byte, integratedTime time.Time) (*TestEntity, error) {
+	leafCert, leafPrivKey, err := ca.GenerateLeafCert(identity, issuer)
+	if err != nil {
+		return nil, err
+	}
+
+	signer, err := signature.LoadSignerFromAlgorithmDetails(leafPrivKey, ca.signingAlgorithmDetails)
+	if err != nil {
+		return nil, err
+	}
+
+	dsseSigner, err := dsse.NewEnvelopeSigner(&sigdsse.SignerAdapter{
+		SignatureSigner: signer,
+		Pub:             leafCert.PublicKey,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	envelope, err := dsseSigner.SignPayload(context.Background(), "application/vnd.in-toto+json", envelopeBody)
+	if err != nil {
+		return nil, err
+	}
+
+	sig, err := base64.StdEncoding.DecodeString(envelope.Signatures[0].Sig)
+	if err != nil {
+		return nil, err
+	}
+
+	tsr, err := generateTimestampingResponse(sig, ca.tsaCA.Leaf, ca.tsaLeafKey)
+	if err != nil {
+		return nil, err
+	}
+
+	tlogEntry, err := ca.generateTlogEntryHashedRekordV2(leafCert, envelope.PayloadType, envelopeBody, sig, integratedTime.Unix())
+	if err != nil {
+		return nil, err
+	}
+
+	return &TestEntity{
+		certChain:   []*x509.Certificate{leafCert, ca.fulcioCA.Intermediates[0], ca.fulcioCA.Root},
+		timestamps:  [][]byte{tsr},
+		envelope:    envelope,
+		tlogEntries: []*tlog.Entry{tlogEntry},
+	}, nil
+}
+
+func (ca *VirtualSigstore) generateTlogEntryHashedRekordV2(leafCert *x509.Certificate, payloadType string, payload []byte, sig []byte, integratedTime int64) (*tlog.Entry, error) {
+	hf := ca.signingAlgorithmDetails.GetHashType()
+	hasher := hf.New()
+	hasher.Write(dsse.PAE(payloadType, payload))
+	digest := hasher.Sum(nil)
+
+	entryPB := &rekortilespb.Entry{
+		ApiVersion: "0.0.2",
+		Kind:       "hashedrekord",
+		Spec: &rekortilespb.Spec{
+			Spec: &rekortilespb.Spec_HashedRekordV002{
+				HashedRekordV002: &rekortilespb.HashedRekordLogEntryV002{
+					Data: &v1.HashOutput{
+						Algorithm: ca.signingAlgorithmDetails.GetProtoHashType(),
+						Digest:    digest,
+					},
+					Signature: &rekortilespb.Signature{
+						Content: sig,
+						Verifier: &rekortilespb.Verifier{
+							KeyDetails: ca.signingAlgorithmDetails.GetSignatureAlgorithm(),
+							Verifier: &rekortilespb.Verifier_X509Certificate{
+								X509Certificate: &v1.X509Certificate{
+									RawBytes: leafCert.Raw,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	serialized, err := protojson.Marshal(entryPB)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling rekor v2 entry: %w", err)
+	}
+	// Mirror the server-side pipeline (rekor-tiles internal/server/service.go):
+	// protojson.Marshal -> jsoncanonicalizer.Transform. Without canonicalizing,
+	// the leaf the verifier reconstructs from the bundle won't match this
+	// test fixture.
+	body, err := jsoncanonicalizer.Transform(serialized)
+	if err != nil {
+		return nil, fmt.Errorf("canonicalizing rekor v2 entry: %w", err)
+	}
+
+	// Single-leaf tree: log index 0, tree size 1, root hash == leaf hash,
+	// no sibling hashes needed.
+	leafHash := rfc6962.DefaultHasher.HashLeaf(body)
+	rekorLogs := ca.RekorLogs()
+	rekorLogID, err := getLogID(ca.rekorKey.Public())
+	if err != nil {
+		return nil, err
+	}
+	rekorLog, ok := rekorLogs[rekorLogID]
+	if !ok {
+		return nil, fmt.Errorf("rekor log %s not found", rekorLogID)
+	}
+	u, err := url.Parse(rekorLog.BaseURL)
+	if err != nil {
+		return nil, fmt.Errorf("parsing rekor BaseURL: %w", err)
+	}
+	origin := u.Hostname()
+
+	sv, err := signature.LoadECDSASignerVerifier(ca.rekorKey, crypto.SHA256)
+	if err != nil {
+		return nil, err
+	}
+	noteSigner, err := rekornote.NewNoteSigner(context.Background(), origin, sv)
+	if err != nil {
+		return nil, err
+	}
+	cpRaw := f_log.Checkpoint{
+		Origin: origin,
+		Size:   1,
+		Hash:   leafHash,
+	}.Marshal()
+	signedNote, err := note.Sign(&note.Note{Text: string(cpRaw)}, noteSigner)
+	if err != nil {
+		return nil, fmt.Errorf("signing checkpoint: %w", err)
+	}
+
+	rekorLogIDRaw, err := hex.DecodeString(rekorLogID)
+	if err != nil {
+		return nil, err
+	}
+
+	tle := &protorekor.TransparencyLogEntry{
+		LogIndex:       0,
+		LogId:          &v1.LogId{KeyId: rekorLogIDRaw},
+		KindVersion:    &protorekor.KindVersion{Kind: "hashedrekord", Version: "0.0.2"},
+		IntegratedTime: integratedTime,
+		InclusionProof: &protorekor.InclusionProof{
+			LogIndex:   0,
+			TreeSize:   1,
+			RootHash:   leafHash,
+			Hashes:     [][]byte{},
+			Checkpoint: &protorekor.Checkpoint{Envelope: string(signedNote)},
+		},
+		CanonicalizedBody: body,
+	}
+
+	return tlog.NewTlogEntry(tle)
 }
 
 func (ca *VirtualSigstore) Sign(identity, issuer string, artifact []byte) (*TestEntity, error) {
@@ -559,7 +725,10 @@ func (ca *VirtualSigstore) RekorLogs() map[string]*root.TransparencyLog {
 		panic(err)
 	}
 	verifiers[logID] = &root.TransparencyLog{
-		BaseURL:             "test",
+		// BaseURL must parse to a non-empty hostname for Rekor v2 verification,
+		// since the checkpoint origin is derived from url.Parse(BaseURL).Hostname().
+		// The hostname matches what GetInclusionProof signs for v1 checkpoints.
+		BaseURL:             "https://rekor.localhost",
 		ID:                  []byte(logID),
 		ValidityPeriodStart: time.Now().Add(-time.Hour),
 		ValidityPeriodEnd:   time.Now().Add(time.Hour),

--- a/pkg/tlog/entry.go
+++ b/pkg/tlog/entry.go
@@ -275,11 +275,6 @@ func ValidateEntry(entry *Entry) error {
 			if err != nil {
 				return err
 			}
-		case *rekortilespb.Spec_DsseV002:
-			err := validateDSSEV002Entry(e.DsseV002)
-			if err != nil {
-				return err
-			}
 		default:
 			return fmt.Errorf("unsupported rekor v2 entry type: %T", e)
 		}
@@ -298,16 +293,6 @@ func validateHashedRekordV002Entry(hr *rekortilespb.HashedRekordLogEntryV002) er
 		return fmt.Errorf("missing digest")
 	}
 	return typesverifier.Validate(hr.GetSignature().GetVerifier())
-}
-
-func validateDSSEV002Entry(d *rekortilespb.DSSELogEntryV002) error {
-	if d.GetPayloadHash() == nil {
-		return fmt.Errorf("missing payload")
-	}
-	if len(d.GetSignatures()) == 0 {
-		return fmt.Errorf("missing signatures")
-	}
-	return typesverifier.Validate(d.GetSignatures()[0].GetVerifier())
 }
 
 func (entry *Entry) IntegratedTime() time.Time {
@@ -337,11 +322,8 @@ func (entry *Entry) Signature() []byte {
 		}
 	}
 	if entry.rekorV2Entry != nil {
-		switch e := entry.rekorV2Entry.GetSpec().GetSpec().(type) {
-		case *rekortilespb.Spec_HashedRekordV002:
+		if e, ok := entry.rekorV2Entry.GetSpec().GetSpec().(*rekortilespb.Spec_HashedRekordV002); ok {
 			return e.HashedRekordV002.GetSignature().GetContent()
-		case *rekortilespb.Spec_DsseV002:
-			return e.DsseV002.GetSignatures()[0].GetContent()
 		}
 	}
 
@@ -369,11 +351,8 @@ func (entry *Entry) PublicKey() any {
 		certBytes = certBlock.Bytes
 	} else if entry.rekorV2Entry != nil {
 		var verifier *rekortilespb.Verifier
-		switch e := entry.rekorV2Entry.GetSpec().GetSpec().(type) {
-		case *rekortilespb.Spec_HashedRekordV002:
+		if e, ok := entry.rekorV2Entry.GetSpec().GetSpec().(*rekortilespb.Spec_HashedRekordV002); ok {
 			verifier = e.HashedRekordV002.GetSignature().GetVerifier()
-		case *rekortilespb.Spec_DsseV002:
-			verifier = e.DsseV002.GetSignatures()[0].GetVerifier()
 		}
 		if verifier == nil {
 			return nil
@@ -423,6 +402,10 @@ func (entry *Entry) TransparencyLogEntry() *v1.TransparencyLogEntry {
 	return entry.tle
 }
 
+func (entry *Entry) IsRekorV2() bool {
+	return entry != nil && entry.rekorV2Entry != nil
+}
+
 func (entry *Entry) GetHashedRekordDigest() (digest []byte, algorithm string, ok bool) {
 	if entry == nil {
 		return nil, "", false
@@ -455,16 +438,7 @@ func (entry *Entry) GetDssePayloadHash() (digest []byte, ok bool) {
 	if entry == nil {
 		return nil, false
 	}
-	if entry.rekorV2Entry != nil {
-		spec := entry.rekorV2Entry.GetSpec()
-		if spec != nil {
-			if e, ok := spec.GetSpec().(*rekortilespb.Spec_DsseV002); ok {
-				if e.DsseV002 != nil && e.DsseV002.GetPayloadHash() != nil {
-					return e.DsseV002.GetPayloadHash().Digest, true
-				}
-			}
-		}
-	} else if entry.rekorV1Entry != nil {
+	if entry.rekorV1Entry != nil {
 		switch e := entry.rekorV1Entry.(type) {
 		case *dsse_v001.V001Entry:
 			if e.DSSEObj.PayloadHash.Value != nil {
@@ -606,7 +580,7 @@ func unmarshalRekorV2Entry(body []byte) (*rekortilespb.Entry, error) {
 	spec := logEntryBody.GetSpec().GetSpec()
 	allowedAPIVersion := ""
 	switch spec.(type) {
-	case *rekortilespb.Spec_HashedRekordV002, *rekortilespb.Spec_DsseV002:
+	case *rekortilespb.Spec_HashedRekordV002:
 		allowedAPIVersion = "0.0.2"
 	default:
 		return nil, ErrInvalidRekorV2Entry

--- a/pkg/tlog/entry_test.go
+++ b/pkg/tlog/entry_test.go
@@ -322,6 +322,35 @@ func TestUnmarshalRekorV2EntryRejectsWrongApiVersionForEntryType(t *testing.T) {
 	assert.ErrorIs(t, err, ErrInvalidRekorV2Entry)
 }
 
+// Rekor v2 only supports hashedrekord, so a v2 entry with a DSSE spec must be rejected.
+func TestUnmarshalRekorV2EntryRejectsDsseKind(t *testing.T) {
+	body := []byte(`{
+  "apiVersion": "0.0.2",
+  "kind": "dsse",
+  "spec": {
+    "dsseV002": {
+      "payloadHash": {
+        "algorithm": "SHA2_256",
+        "digest": "dyj4ednYHjN4/zsjjBeeLahS9slp97Z67LTAVxjrjXw="
+      },
+      "signatures": [
+        {
+          "content": "MEQCIB+YPa9o3SN0sQ4uduGf+mZxwFfOhFZ0Cgy+p7Vt1o2SAiAPFDHqOAJLYmvtCWOsDyNY1H4V3zm4NEDYs3NyvHh1Pg==",
+          "verifier": {
+            "keyDetails": "PKIX_ECDSA_P256_SHA_256",
+            "publicKey": {
+              "rawBytes": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE2slOf8eZcj2moW2t4UFj7vCL6QpDzkDqqSUmm4OJCVvIauKLxm0aGs3VMPPfauMPaMutn0/s3jg0rroFxoicyg=="
+            }
+          }
+        }
+      ]
+    }
+  }
+}`)
+	_, err := unmarshalRekorV2Entry(body)
+	assert.ErrorIs(t, err, ErrInvalidRekorV2Entry)
+}
+
 func TestUnmarshalRekorV2EntryWithEmptyBody(t *testing.T) {
 	var body = []byte("{}")
 
@@ -354,24 +383,6 @@ func TestGetDssePayloadHash(t *testing.T) {
 		wantDigest []byte
 		wantOk     bool
 	}{
-		{
-			name: "dsse 0.0.2",
-			entry: &Entry{
-				rekorV2Entry: &rekortilespb.Entry{
-					Spec: &rekortilespb.Spec{
-						Spec: &rekortilespb.Spec_DsseV002{
-							DsseV002: &rekortilespb.DSSELogEntryV002{
-								PayloadHash: &protocommon.HashOutput{
-									Digest: payloadHash,
-								},
-							},
-						},
-					},
-				},
-			},
-			wantDigest: payloadHash,
-			wantOk:     true,
-		},
 		{
 			name: "dsse 0.0.1",
 			entry: &Entry{
@@ -409,26 +420,8 @@ func TestGetDssePayloadHash(t *testing.T) {
 			wantOk:     false,
 		},
 		{
-			name: "V2 DSSE Nil Spec",
-			entry: &Entry{
-				rekorV2Entry: &rekortilespb.Entry{},
-			},
-			wantDigest: nil,
-			wantOk:     false,
-		},
-		{
 			name:       "Nil Receiver",
 			entry:      nil,
-			wantDigest: nil,
-			wantOk:     false,
-		},
-		{
-			name: "V2 DSSE Empty Spec",
-			entry: &Entry{
-				rekorV2Entry: &rekortilespb.Entry{
-					Spec: &rekortilespb.Spec{},
-				},
-			},
 			wantDigest: nil,
 			wantOk:     false,
 		},

--- a/pkg/verify/tlog.go
+++ b/pkg/verify/tlog.go
@@ -99,6 +99,9 @@ func VerifyTlogEntry(entity SignedEntity, trustedMaterial root.TrustedMaterial, 
 		if !entry.HasInclusionPromise() && !entry.HasInclusionProof() {
 			return nil, fmt.Errorf("entry must contain an inclusion proof and/or promise")
 		}
+		if entry.IsRekorV2() && !entry.HasInclusionProof() {
+			return nil, fmt.Errorf("rekor v2 entries must have an inclusion proof")
+		}
 		if entry.HasInclusionPromise() {
 			err = tlog.VerifySET(entry, rekorLogs)
 			if err != nil {
@@ -129,80 +132,73 @@ func VerifyTlogEntry(entity SignedEntity, trustedMaterial root.TrustedMaterial, 
 				if err != nil {
 					return nil, fmt.Errorf("loading note verifier: %w", err)
 				}
-				if _, _, ok := entry.GetHashedRekordDigest(); ok {
-					entryHash, err := reconstructV2EntryHash(sigContent, verificationContent, trustedMaterial, entitySignature)
-					if err != nil {
-						return nil, err
-					}
-					if err := rekorVerify.VerifyLogEntryWithHash(entry.TransparencyLogEntry(), noteVerifier, entryHash); err != nil {
-						return nil, fmt.Errorf("verifying log entry: %w", err)
-					}
-				} else {
-					// TODO: once the sign path encodes DSSE envelopes as hashedrekord, require all v2 entries to be hashedrekord
-					if err := rekorVerify.VerifyLogEntry(entry.TransparencyLogEntry(), noteVerifier); err != nil {
-						return nil, fmt.Errorf("verifying log entry: %w", err)
-					}
+				entryHash, err := reconstructV2EntryHash(sigContent, verificationContent, trustedMaterial, entitySignature)
+				if err != nil {
+					return nil, err
+				}
+				if err := rekorVerify.VerifyLogEntryWithHash(entry.TransparencyLogEntry(), noteVerifier, entryHash); err != nil {
+					return nil, fmt.Errorf("verifying log entry: %w", err)
 				}
 			}
 			// DO NOT use timestamp with only an inclusion proof, because it is not signed metadata
 		}
 
-		// Ensure entry signature matches signature from bundle
-		if !bytes.Equal(entry.Signature(), entitySignature) {
-			return nil, errors.New("transparency log signature does not match")
-		}
+		// Rekor v1 only: enforce bundle ↔ entry equality field-by-field.
+		// Rekor v2 skips this because the reconstructed hash already commits
+		// to the signature, public key, and digest from the bundle.
+		if !entry.IsRekorV2() {
+			if !bytes.Equal(entry.Signature(), entitySignature) {
+				return nil, errors.New("transparency log signature does not match")
+			}
 
-		// Ensure entry certificate matches bundle certificate
-		if !verificationContent.CompareKey(entry.PublicKey(), trustedMaterial) {
-			return nil, errors.New("transparency log certificate does not match")
-		}
+			if !verificationContent.CompareKey(entry.PublicKey(), trustedMaterial) {
+				return nil, errors.New("transparency log certificate does not match")
+			}
 
-		// Ensure that the digest/payload in the bundle matches the tlog entry
-		switch {
-		case sigContent.MessageSignatureContent() != nil:
-			// This message digest must be compared to the provided artifact
-			msgSig := sigContent.MessageSignatureContent()
-			entityDigest := msgSig.Digest()
-			entityAlgo := msgSig.DigestAlgorithm()
+			switch {
+			case sigContent.MessageSignatureContent() != nil:
+				msgSig := sigContent.MessageSignatureContent()
+				entityDigest := msgSig.Digest()
+				entityAlgo := msgSig.DigestAlgorithm()
 
-			entryDigest, entryAlgo, ok := entry.GetHashedRekordDigest()
-			if !ok {
-				return nil, errors.New("transparency log entry is not a hashedrekord or missing digest")
+				entryDigest, entryAlgo, ok := entry.GetHashedRekordDigest()
+				if !ok {
+					return nil, errors.New("transparency log entry is not a hashedrekord or missing digest")
+				}
+				entityHashFunc, err := algStringToHashFunc(entityAlgo)
+				if err != nil {
+					return nil, err
+				}
+				entryHashFunc, err := algStringToHashFunc(entryAlgo)
+				if err != nil {
+					return nil, err
+				}
+				if entityHashFunc != entryHashFunc {
+					return nil, fmt.Errorf("transparency log hashedrekord entry digest algorithm mismatch: %s != %s", entityAlgo, entryAlgo)
+				}
+				if !bytes.Equal(entityDigest, entryDigest) {
+					return nil, fmt.Errorf("transparency log hashedrekord entry digest %s does not match artifact %s", hex.EncodeToString(entryDigest), hex.EncodeToString(entityDigest))
+				}
+			case sigContent.EnvelopeContent() != nil:
+				env := sigContent.EnvelopeContent().RawEnvelope()
+				if env == nil {
+					return nil, errors.New("bundle envelope is missing")
+				}
+				payloadBytes, err := base64.StdEncoding.DecodeString(env.Payload)
+				if err != nil {
+					return nil, fmt.Errorf("failed to decode envelope payload: %w", err)
+				}
+				payloadHash := sha256.Sum256(payloadBytes)
+				entryDigest, ok := entry.GetDssePayloadHash()
+				if !ok {
+					return nil, errors.New("transparency log rekor v1 entry is not a dsse_v001 or intoto_v002 entry")
+				}
+				if !bytes.Equal(payloadHash[:], entryDigest) {
+					return nil, fmt.Errorf("transparency log dsse/intoto entry payload hash %s does not match envelope payload hash %s", hex.EncodeToString(payloadHash[:]), hex.EncodeToString(entryDigest))
+				}
+			default:
+				return nil, errors.New("bundle must contain either a message signature or an envelope")
 			}
-			entityHashFunc, err := algStringToHashFunc(entityAlgo)
-			if err != nil {
-				return nil, err
-			}
-			entryHashFunc, err := algStringToHashFunc(entryAlgo)
-			if err != nil {
-				return nil, err
-			}
-			if entityHashFunc != entryHashFunc {
-				return nil, fmt.Errorf("transparency log hashedrekord entry digest algorithm mismatch: %s != %s", entityAlgo, entryAlgo)
-			}
-			if !bytes.Equal(entityDigest, entryDigest) {
-				return nil, fmt.Errorf("transparency log hashedrekord entry digest %s does not match artifact %s", hex.EncodeToString(entryDigest), hex.EncodeToString(entityDigest))
-			}
-		case sigContent.EnvelopeContent() != nil:
-			envContent := sigContent.EnvelopeContent()
-			env := envContent.RawEnvelope()
-			if env == nil {
-				return nil, errors.New("bundle envelope is missing")
-			}
-			payloadBytes, err := base64.StdEncoding.DecodeString(env.Payload)
-			if err != nil {
-				return nil, fmt.Errorf("failed to decode envelope payload: %w", err)
-			}
-			payloadHash := sha256.Sum256(payloadBytes) // SHA256 is hardcoded in Rekor v1 and v2 for payload hash
-			entryDigest, ok := entry.GetDssePayloadHash()
-			if !ok {
-				return nil, errors.New("transparency log entry is not a dsse or intoto entry or missing payload hash")
-			}
-			if !bytes.Equal(payloadHash[:], entryDigest) {
-				return nil, fmt.Errorf("transparency log dsse/intoto entry payload hash %s does not match envelope payload hash %s", hex.EncodeToString(payloadHash[:]), hex.EncodeToString(entryDigest))
-			}
-		default:
-			return nil, errors.New("bundle must contain either a message signature or an envelope")
 		}
 
 		// Check tlog entry time against bundle certificates
@@ -227,9 +223,7 @@ func VerifyTlogEntry(entity SignedEntity, trustedMaterial root.TrustedMaterial, 
 	return verifiedTimestamps, nil
 }
 
-// reconstructV2EntryHash rebuilds a Rekor v2 hashedrekord entry hash from
-// bundle contents, so inclusion can be verified without relying on the
-// canonicalized body returned by Rekor.
+// reconstructV2EntryHash rebuilds a Rekor v2 entry hash from bundle content.
 func reconstructV2EntryHash(sigContent SignatureContent, verificationContent VerificationContent, trustedMaterial root.TrustedMaterial, entitySignature []byte) ([]byte, error) {
 	var (
 		pubKey        crypto.PublicKey

--- a/pkg/verify/tlog_test.go
+++ b/pkg/verify/tlog_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/secure-systems-lab/go-securesystemslib/dsse"
+	v1 "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
 	"github.com/sigstore/sigstore-go/pkg/root"
 	"github.com/sigstore/sigstore-go/pkg/testing/ca"
 	"github.com/sigstore/sigstore-go/pkg/tlog"
@@ -429,4 +430,35 @@ func (c *mismatchEnvelopeContentWrapper) RawEnvelope() *dsse.Envelope {
 		Signatures:  env.Signatures,
 	}
 	return clone
+}
+
+// TestTlogVerifierDSSEHashedRekordV2 verifies a DSSE envelope encoded as a Rekor v2 hashedrekord.
+func TestTlogVerifierDSSEHashedRekordV2(t *testing.T) {
+	statement := []byte(`{"_type":"https://in-toto.io/Statement/v0.1","predicateType":"customFoo","subject":[{"name":"subject","digest":{"sha256":"deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"}}],"predicate":{}}`)
+
+	for _, tc := range []struct {
+		name string
+		alg  v1.PublicKeyDetails
+	}{
+		{"sha256", v1.PublicKeyDetails_PKIX_ECDSA_P256_SHA_256},
+		{"sha384", v1.PublicKeyDetails_PKIX_ECDSA_P384_SHA_384},
+		{"sha512", v1.PublicKeyDetails_PKIX_ECDSA_P521_SHA_512},
+		{"ed25519ph", v1.PublicKeyDetails_PKIX_ED25519_PH},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			virtualSigstore, err := ca.NewVirtualSigstoreWithSigningAlg(tc.alg)
+			assert.NoError(t, err)
+
+			entity, err := virtualSigstore.AttestHashedRekordV2("foo@example.com", "issuer", statement)
+			assert.NoError(t, err)
+
+			_, err = verify.VerifyTlogEntry(entity, virtualSigstore, 1, true)
+			assert.NoError(t, err)
+
+			// Tampering with the envelope changes the reconstructed leaf hash, failing inclusion proof.
+			mismatch := &mismatchEnvelopeEntity{TestEntity: entity}
+			_, err = verify.VerifyTlogEntry(mismatch, virtualSigstore, 1, true)
+			assert.ErrorContains(t, err, "verifying inclusion")
+		})
+	}
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/sigstore/sigstore/pkg/signature/options"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -167,20 +168,21 @@ func TestSignVerify(t *testing.T) {
 			digestAlg:          crypto.SHA256,
 			rekorVersion:       2,
 			expectedTimestamps: 1,
-			signingAlg:         protocommon.PublicKeyDetails_PKIX_ED25519,
+			signingAlg:         protocommon.PublicKeyDetails_PKIX_ED25519_PH,
+			useKey:             true,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			keypair, err := sign.NewEphemeralKeypair(&sign.EphemeralKeypairOptions{Algorithm: test.signingAlg})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			if test.useKey {
 				initTrustedRootWithKey(t, test.signingAlg, keypair.GetPublicKey(), &opts)
 			}
 
 			protoBundle, err := signContent(signingConfig, token, test.content, test.rekorVersion, keypair, test.useKey, opts)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			result, err := verifyBundle(protoBundle, issuerURL, defaultCertID, getDigest(artifactData, test.digestAlg), test.useKey, opts.TrustedRoot)
 


### PR DESCRIPTION
## Summary

Implements the encoding proposed in sigstore/architecture-docs#63 (rekor-v2-spec §6.1.4): on Rekor v2, DSSE envelopes are uploaded as a `hashedrekord` whose digest covers `Hash(PAE(payloadType, payload))`, where `Hash` is derived from the signing algorithm (ECDSA P-256 → SHA-256, P-384 → SHA-384, etc.; ed25519 must use ed25519ph).

On the verification side, the canonicalized Rekor entry body is now reconstructed from the bundle contents rather than relying on the body in the bundle.

Rekor v1 behavior is unchanged.