### PR TITLE
Prevent multi-log threshold bypasses via single compromised log

### DIFF
--- a/pkg/verify/sct.go
+++ b/pkg/verify/sct.go
@@ -50,12 +50,16 @@ func VerifySignedCertificateTimestamp(chains [][]*x509.Certificate, threshold in
 		return err
 	}
 
-	verified := 0
+	verifiedLogs := make(map[string]bool)
 	for _, sct := range scts {
 		encodedKeyID := hex.EncodeToString(sct.LogID.KeyID[:])
+		if verifiedLogs[encodedKeyID] {
+			// Skip verification of SCTs from the same log after one successful verification.
+			continue
+		}
 		key, ok := ctlogs[encodedKeyID]
 		if !ok {
-			// skip entries the trust root cannot verify
+			// Skip entries the trust root cannot verify
 			continue
 		}
 
@@ -87,13 +91,14 @@ func VerifySignedCertificateTimestamp(chains [][]*x509.Certificate, threshold in
 
 			err = ctutil.VerifySCT(key.PublicKey, fulcioChain, sct, true)
 			if err == nil {
-				verified++
+				verifiedLogs[encodedKeyID] = true
+				break
 			}
 		}
 	}
 
-	if verified < threshold {
-		return fmt.Errorf("only able to verify %d SCT entries; unable to meet threshold of %d", verified, threshold)
+	if len(verifiedLogs) < threshold {
+		return fmt.Errorf("only able to verify %d SCT entries; unable to meet threshold of %d", len(verifiedLogs), threshold)
 	}
 
 	return nil

--- a/pkg/verify/sct_test.go
+++ b/pkg/verify/sct_test.go
@@ -67,6 +67,10 @@ func TestVerifySignedCertificateTimestamp(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	anotherLogID, err := getCTLogID(&anotherPrivateKey.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
 	tests := []struct {
 		name            string
 		getCertFn       func() *x509.Certificate
@@ -354,7 +358,7 @@ func TestVerifySignedCertificateTimestamp(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "threshold of 2 with 2 valid scts",
+			name: "threshold of 2 with 2 valid scts from same log (fails)",
 			getCertFn: func() *x509.Certificate {
 				return embedSCTs(t, privateKey, skid, createBaseCert(t, privateKey, skid, big.NewInt(1)), []ct.SignedCertificateTimestamp{
 					{
@@ -375,6 +379,41 @@ func TestVerifySignedCertificateTimestamp(t *testing.T) {
 				transparencyLog: map[string]*root.TransparencyLog{
 					hex.EncodeToString(logID[:]): {
 						PublicKey: &privateKey.PublicKey,
+					},
+				},
+				cas: []root.CertificateAuthority{
+					&root.FulcioCertificateAuthority{
+						Root: caCert,
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "threshold of 2 with 2 valid scts from different logs (succeeds)",
+			getCertFn: func() *x509.Certificate {
+				return embedSCTs(t, []*rsa.PrivateKey{privateKey, anotherPrivateKey}, skid, createBaseCert(t, privateKey, skid, big.NewInt(1)), []ct.SignedCertificateTimestamp{
+					{
+						SCTVersion: ct.V1,
+						Timestamp:  12345,
+						LogID:      ct.LogID{KeyID: logID},
+					},
+					{
+						SCTVersion: ct.V1,
+						Timestamp:  99,
+						LogID:      ct.LogID{KeyID: anotherLogID},
+					},
+				})
+			},
+			chain:     []*x509.Certificate{caCert},
+			threshold: 2,
+			trustedMaterial: &fakeTrustedMaterial{
+				transparencyLog: map[string]*root.TransparencyLog{
+					hex.EncodeToString(logID[:]): {
+						PublicKey: &privateKey.PublicKey,
+					},
+					hex.EncodeToString(anotherLogID[:]): {
+						PublicKey: &anotherPrivateKey.PublicKey,
 					},
 				},
 				cas: []root.CertificateAuthority{
@@ -415,9 +454,19 @@ func createBaseCert(t *testing.T, privateKey *rsa.PrivateKey, skid []byte, seria
 	return parsedCert
 }
 
-func embedSCTs(t *testing.T, privateKey *rsa.PrivateKey, skid []byte, preCert *x509.Certificate, sctInput []ct.SignedCertificateTimestamp) *x509.Certificate {
+func embedSCTs(t *testing.T, privateKeyOrKeys any, skid []byte, preCert *x509.Certificate, sctInput []ct.SignedCertificateTimestamp) *x509.Certificate {
+	var keys []*rsa.PrivateKey
+	switch k := privateKeyOrKeys.(type) {
+	case *rsa.PrivateKey:
+		keys = []*rsa.PrivateKey{k}
+	case []*rsa.PrivateKey:
+		keys = k
+	default:
+		t.Fatalf("unexpected type for privateKeyOrKeys: %T", privateKeyOrKeys)
+	}
+
 	scts := make([]*ct.SignedCertificateTimestamp, 0)
-	for _, s := range sctInput {
+	for i, s := range sctInput {
 		logEntry := ct.LogEntry{
 			Leaf: ct.MerkleTreeLeaf{
 				Version:  ct.V1,
@@ -437,7 +486,8 @@ func embedSCTs(t *testing.T, privateKey *rsa.PrivateKey, skid []byte, preCert *x
 			t.Fatal(err)
 		}
 		h := sha256.Sum256(data)
-		signature, err := privateKey.Sign(rand.Reader, h[:], crypto.SHA256)
+		key := keys[i%len(keys)]
+		signature, err := key.Sign(rand.Reader, h[:], crypto.SHA256)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -477,7 +527,8 @@ func embedSCTs(t *testing.T, privateKey *rsa.PrivateKey, skid []byte, preCert *x
 			},
 		},
 	}
-	certDERBytes, err := x509.CreateCertificate(rand.Reader, cert, cert, &privateKey.PublicKey, privateKey)
+	issuerKey := keys[0]
+	certDERBytes, err := x509.CreateCertificate(rand.Reader, cert, cert, &issuerKey.PublicKey, issuerKey)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/verify/tlog.go
+++ b/pkg/verify/tlog.go
@@ -70,8 +70,9 @@ func VerifyTlogEntry(entity SignedEntity, trustedMaterial root.TrustedMaterial, 
 		return nil, err
 	}
 
-	verifiedTimestamps := []root.Timestamp{}
-	logEntriesVerified := 0
+	var verifiedTimestamps []root.Timestamp
+	verifiedLogIDsMap := make(map[string]bool)
+	hasTimestampMap := make(map[string]bool)
 
 	for _, entry := range entries {
 		err := tlog.ValidateEntry(entry)
@@ -96,9 +97,6 @@ func VerifyTlogEntry(entity SignedEntity, trustedMaterial root.TrustedMaterial, 
 			if err != nil {
 				// skip entries the trust root cannot verify
 				continue
-			}
-			if trustIntegratedTime {
-				verifiedTimestamps = append(verifiedTimestamps, root.Timestamp{Time: entry.IntegratedTime(), URI: tlogVerifier.BaseURL})
 			}
 		}
 		if entry.HasInclusionProof() {
@@ -194,11 +192,15 @@ func VerifyTlogEntry(entity SignedEntity, trustedMaterial root.TrustedMaterial, 
 		}
 
 		// successful log entry verification
-		logEntriesVerified++
+		verifiedLogIDsMap[keyID] = true
+		if trustIntegratedTime && entry.HasInclusionPromise() && !hasTimestampMap[keyID] {
+			hasTimestampMap[keyID] = true
+			verifiedTimestamps = append(verifiedTimestamps, root.Timestamp{Time: entry.IntegratedTime(), URI: tlogVerifier.BaseURL})
+		}
 	}
 
-	if logEntriesVerified < logThreshold {
-		return nil, fmt.Errorf("not enough verified log entries from transparency log: %d < %d", logEntriesVerified, logThreshold)
+	if len(verifiedLogIDsMap) < logThreshold {
+		return nil, fmt.Errorf("not enough verified log entries from transparency log: %d < %d", len(verifiedLogIDsMap), logThreshold)
 	}
 
 	return verifiedTimestamps, nil

--- a/pkg/verify/tlog_test.go
+++ b/pkg/verify/tlog_test.go
@@ -16,6 +16,7 @@ package verify_test
 
 import (
 	"encoding/base64"
+	"encoding/hex"
 	"strings"
 	"testing"
 	"time"
@@ -194,6 +195,73 @@ func TestDuplicateTlogEntries(t *testing.T) {
 
 	_, err = verify.VerifyTlogEntry(&dupTlogEntity{entity}, virtualSigstore, 1, true)
 	assert.ErrorContains(t, err, "duplicate tlog entries found") // duplicate tlog entries should fail to verify
+}
+
+type sameLogIDDifferentIndexEntity struct {
+	*ca.TestEntity
+	VirtualSigstore *ca.VirtualSigstore
+}
+
+func (e *sameLogIDDifferentIndexEntity) TlogEntries() ([]*tlog.Entry, error) {
+	entries, err := e.TestEntity.TlogEntries()
+	if err != nil {
+		return nil, err
+	}
+	entry1 := entries[0]
+	body, err := base64.StdEncoding.DecodeString(entry1.Body().(string))
+	if err != nil {
+		return nil, err
+	}
+
+	rekorLogID, err := e.VirtualSigstore.RekorLogID()
+	if err != nil {
+		return nil, err
+	}
+	rekorLogIDRaw, err := hex.DecodeString(rekorLogID)
+	if err != nil {
+		return nil, err
+	}
+
+	b2 := tlog.RekorPayload{
+		LogID:          rekorLogID,
+		IntegratedTime: entry1.IntegratedTime().Unix(),
+		LogIndex:       entry1.LogIndex() + 1,
+		Body:           entry1.Body().(string),
+	}
+	set2, err := e.VirtualSigstore.RekorSignPayload(b2)
+	if err != nil {
+		return nil, err
+	}
+
+	entry2, err := tlog.NewEntry(body, entry1.IntegratedTime().Unix(), entry1.LogIndex()+1, rekorLogIDRaw, set2, nil) //nolint:staticcheck
+	if err != nil {
+		return nil, err
+	}
+	return []*tlog.Entry{entry1, entry2}, nil
+}
+
+func TestSameLogIDDifferentIndexTlogEntries(t *testing.T) {
+	virtualSigstore, err := ca.NewVirtualSigstore()
+	assert.NoError(t, err)
+
+	statement := []byte(`{"_type":"https://in-toto.io/Statement/v0.1","predicateType":"customFoo","subject":[{"name":"subject","digest":{"sha256":"deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"}}],"predicate":{}}`)
+	entity, err := virtualSigstore.Attest("foo@example.com", "issuer", statement)
+	assert.NoError(t, err)
+
+	wrappedEntity := &sameLogIDDifferentIndexEntity{
+		TestEntity:      entity,
+		VirtualSigstore: virtualSigstore,
+	}
+
+	// Threshold of 1 should succeed with 2 entries from the same log
+	ts, err := verify.VerifyTlogEntry(wrappedEntity, virtualSigstore, 1, true)
+	assert.NoError(t, err)
+	// It must return exactly 1 observer timestamp (deduplicated)
+	assert.Len(t, ts, 1)
+
+	// Threshold of 2 should fail because both entries are from the same log (only 1 witness)
+	_, err = verify.VerifyTlogEntry(wrappedEntity, virtualSigstore, 2, true)
+	assert.ErrorContains(t, err, "not enough verified log entries from transparency log")
 }
 
 type tooManyTlogEntriesEntity struct {


### PR DESCRIPTION
A verifier configured with WithTransparencyLog(N>1) or WithSignedCertificateTimestamps(N>1) expected defense-in-depth against the compromise of a single log instance. However, threshold counting treated verified entries per-entry rather than per-log.

As a result, a single compromised transparency log could forge multiple entries with different indices, and a single compromised CT log could verify multiple times (either across multiple certificate chains or via multiple embedded SCTs), fully satisfying the multi-log threshold requirements and defeating the multi-log policy.

This change ensures that a threshold of N can only be satisfied by N independent logs by enforcing that each distinct transparency log and CT log identity counts as at most one witness towards threshold and observer timestamp policies.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
