### PR TITLE
Reject certificate identity with no SAN or issuer criteria

### DIFF
--- a/pkg/verify/certificate_identity.go
+++ b/pkg/verify/certificate_identity.go
@@ -118,6 +118,9 @@ func (s *SubjectAlternativeNameMatcher) MarshalJSON() ([]byte, error) {
 // Verify checks if the actualCert matches the SANMatcher's Value and
 // Regexp – if those values have been provided.
 func (s SubjectAlternativeNameMatcher) Verify(actualCert certificate.Summary) error {
+	if s.SubjectAlternativeName == "" && s.Regexp.String() == "" {
+		return errors.New("when verifying a certificate identity, there must be subject alternative name criteria")
+	}
 	if s.SubjectAlternativeName != "" &&
 		actualCert.SubjectAlternativeName != s.SubjectAlternativeName {
 		return &ErrValueMismatch{"SAN", string(s.SubjectAlternativeName), string(actualCert.SubjectAlternativeName)}
@@ -150,6 +153,9 @@ func (i *IssuerMatcher) MarshalJSON() ([]byte, error) {
 }
 
 func (i IssuerMatcher) Verify(actualCert certificate.Summary) error {
+	if i.Issuer == "" && i.Regexp.String() == "" {
+		return errors.New("when verifying a certificate identity, must specify Issuer criteria")
+	}
 	if i.Issuer != "" &&
 		actualCert.Issuer != i.Issuer {
 		return &ErrValueMismatch{"issuer", string(i.Issuer), string(actualCert.Issuer)}

--- a/pkg/verify/certificate_identity_test.go
+++ b/pkg/verify/certificate_identity_test.go
@@ -58,23 +58,27 @@ func TestCertificateIdentityVerify(t *testing.T) {
 	}
 
 	// First, let's test happy paths:
-	issuerOnlyID, _ := certIDForTesting("", "", ActionsIssuerValue, "", "")
-	assert.NoError(t, issuerOnlyID.Verify(actualCert))
+	values, _ := certIDForTesting(SigstoreSanValue, "", ActionsIssuerValue, "", "")
+	assert.NoError(t, values.Verify(actualCert))
 
-	issuerOnlyRegex, _ := certIDForTesting("", "", "", ActionsIssuerRegex, "")
-	assert.NoError(t, issuerOnlyRegex.Verify(actualCert))
-
-	sanValueOnly, _ := certIDForTesting(SigstoreSanValue, "", "", "", "")
-	assert.NoError(t, sanValueOnly.Verify(actualCert))
-
-	sanRegexOnly, _ := certIDForTesting("", SigstoreSanRegex, "", "", "")
-	assert.NoError(t, sanRegexOnly.Verify(actualCert))
+	regexMatches, _ := certIDForTesting("", SigstoreSanRegex, "", ActionsIssuerRegex, "")
+	assert.NoError(t, regexMatches.Verify(actualCert))
 
 	// multiple values can be specified
 	sanRegexAndIssuer, _ := certIDForTesting("", SigstoreSanRegex, ActionsIssuerValue, "", "github-hosted")
 	assert.NoError(t, sanRegexAndIssuer.Verify(actualCert))
 
 	// unhappy paths:
+	// ensure we error when underspecified
+	empty, _ := certIDForTesting("", "", "", "", "")
+	assert.Error(t, empty.Verify(actualCert))
+
+	justSan, _ := certIDForTesting(SigstoreSanValue, "", "", "", "")
+	assert.Error(t, justSan.Verify(actualCert))
+
+	justIssuerRegex, _ := certIDForTesting("", "", "", ActionsIssuerRegex, "")
+	assert.Error(t, justIssuerRegex.Verify(actualCert))
+
 	// wrong issuer
 	sanRegexAndWrongIssuer, _ := certIDForTesting("", SigstoreSanRegex, "https://token.actions.example.com", "", "")
 	errValueMismatch := &ErrValueMismatch{}


### PR DESCRIPTION
#### Summary

WithCertificateIdentity accepted a certificate identity with no SAN or issuer criteria, which then matches any certificate (#644). NewCertificateIdentity already rejects it;
this moves that check into a validate method so both paths reject an empty identity. SAN-only and issuer-only identities are unaffected.

Reviewers can run go test ./pkg/verify/ -run TestWithCertificateIdentityRejectsEmptyIdentity; it fails before this change and passes after.

Closes #644

#### Release Note

Fixed WithCertificateIdentity accepting a certificate identity with no SAN or issuer criteria, which matched any certificate.

#### Documentation

NONE
