### PR TITLE
Handle 409s from Rekor by fetching the entry

### DIFF
--- a/pkg/sign/transparency.go
+++ b/pkg/sign/transparency.go
@@ -23,6 +23,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"path"
 	"time"
 
 	ssldsse "github.com/secure-systems-lab/go-securesystemslib/dsse"
@@ -58,6 +59,7 @@ const (
 
 type RekorClient interface {
 	CreateLogEntry(params *entries.CreateLogEntryParams, opts ...entries.ClientOption) (*entries.CreateLogEntryCreated, error)
+	GetLogEntryByUUID(params *entries.GetLogEntryByUUIDParams, opts ...entries.ClientOption) (*entries.GetLogEntryByUUIDOK, error)
 }
 
 type RekorV2Client interface {
@@ -217,6 +219,19 @@ func (r *Rekor) getRekorV2TLE(ctx context.Context, keyOrCertPEM []byte, b *proto
 	}
 	tle, err := r.options.ClientV2.Add(ctx, req)
 	if err != nil {
+		// Note: A 409 Conflict from Rekor v2 is currently not handled. The simplest
+		// solution is to sign again to generate a different signature.
+		// If someone wants to gracefully handle a 409 Conflict (e.g. from CI retries),
+		// they would need to:
+		// 1. Extract the log index from the error string (e.g. "an equivalent entry already exists... with index <idx>")
+		//    or from the x-log-index response header.
+		// 2. Fetch the checkpoint from the log's base URL and parse its size and root hash.
+		// 3. Use the tessera HTTP fetcher and ProofBuilder to fetch the inclusion proof for that index.
+		// 4. Fetch the entry bundle for the index, decode it, and extract the matching entry.
+		// 5. Construct the TransparencyLogEntry manually.
+		// However, doing so requires the log's public key (to compute the LogId field), which is
+		// only available from the trusted root, making it impossible to correctly populate the bundle here
+		// without access to the Verifier or TrustedRoot. Thus, we return the error.
 		return nil, fmt.Errorf("adding rekor v2 entry: %w", err)
 	}
 	return tle, nil
@@ -284,11 +299,28 @@ func (r *Rekor) getRekorV1TLE(ctx context.Context, keyOrCertPEM []byte, b *proto
 	}
 
 	resp, err := r.options.Client.CreateLogEntry(params)
+	var entry models.LogEntryAnon
 	if err != nil {
-		return nil, err
+		var conflictErr *entries.CreateLogEntryConflict
+		if errors.As(err, &conflictErr) {
+			uuid := path.Base(conflictErr.Location.String())
+			getParams := entries.NewGetLogEntryByUUIDParamsWithContext(ctx)
+			getParams.SetEntryUUID(uuid)
+			getResp, getErr := r.options.Client.GetLogEntryByUUID(getParams)
+			if getErr != nil {
+				return nil, fmt.Errorf("failed to fetch conflicting entry: %w", getErr)
+			}
+			for _, v := range getResp.Payload {
+				entry = v
+				break
+			}
+		} else {
+			return nil, err
+		}
+	} else {
+		entry = resp.Payload[resp.ETag]
 	}
 
-	entry := resp.Payload[resp.ETag]
 	tlogEntry, err := tle.GenerateTransparencyLogEntry(entry)
 	if err != nil {
 		return nil, err

--- a/pkg/sign/transparency_test.go
+++ b/pkg/sign/transparency_test.go
@@ -20,9 +20,12 @@ import (
 	"crypto/ecdsa"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/go-openapi/strfmt"
 	"github.com/secure-systems-lab/go-securesystemslib/dsse"
 	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
 	protorekor "github.com/sigstore/protobuf-specs/gen/pb-go/rekor/v1"
@@ -103,6 +106,10 @@ func (m *mockRekor) CreateLogEntry(_ *entries.CreateLogEntryParams, _ ...entries
 	return created, nil
 }
 
+func (m *mockRekor) GetLogEntryByUUID(_ *entries.GetLogEntryByUUIDParams, _ ...entries.ClientOption) (*entries.GetLogEntryByUUIDOK, error) {
+	return nil, errors.New("not implemented")
+}
+
 type mockRekorV2 struct{}
 
 func (m *mockRekorV2) Add(_ context.Context, _ any) (*protorekor.TransparencyLogEntry, error) {
@@ -166,6 +173,57 @@ func Test_GetTransparencyLogEntryRekorV2(t *testing.T) {
 	bundle.VerificationMaterial = &protobundle.VerificationMaterial{}
 
 	opts := &RekorOptions{Retries: 1, ClientV2: &mockRekorV2{}, Version: rekorV2}
+	rekor := NewRekor(opts)
+
+	pubkey, err := keypair.GetPublicKeyPem()
+	assert.Nil(t, err)
+
+	err = rekor.GetTransparencyLogEntry(ctx, []byte(pubkey), bundle)
+	assert.Nil(t, err)
+	assert.NotNil(t, bundle.VerificationMaterial.TlogEntries)
+}
+
+type mockRekorConflict struct {
+	mockRekor
+}
+
+func (m *mockRekorConflict) CreateLogEntry(_ *entries.CreateLogEntryParams, _ ...entries.ClientOption) (*entries.CreateLogEntryCreated, error) {
+	return nil, &entries.CreateLogEntryConflict{
+		Location: strfmt.URI("http://rekor.example.com/api/v1/log/entries/abcdef1234567890"),
+	}
+}
+
+func (m *mockRekorConflict) GetLogEntryByUUID(params *entries.GetLogEntryByUUIDParams, _ ...entries.ClientOption) (*entries.GetLogEntryByUUIDOK, error) {
+	if params.EntryUUID != "abcdef1234567890" {
+		return nil, fmt.Errorf("unexpected uuid: %s", params.EntryUUID)
+	}
+
+	created, err := m.mockRekor.CreateLogEntry(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &entries.GetLogEntryByUUIDOK{
+		Payload: created.Payload,
+	}, nil
+}
+
+func Test_GetTransparencyLogEntryConflictV1(t *testing.T) {
+	ctx := context.Background()
+
+	keypair, err := NewEphemeralKeypair(nil)
+	assert.Nil(t, err)
+
+	bundle := &protobundle.Bundle{MediaType: bundleV03MediaType}
+	content := DSSEData{Data: []byte("hello world"), PayloadType: "something"}
+	envelopeBody = content.PreAuthEncoding()
+	signature, digest, err := keypair.SignData(ctx, content.PreAuthEncoding())
+	assert.Nil(t, err)
+
+	content.Bundle(bundle, signature, digest, keypair.GetHashAlgorithm())
+	bundle.VerificationMaterial = &protobundle.VerificationMaterial{}
+
+	opts := &RekorOptions{Retries: 1, Client: &mockRekorConflict{}}
 	rekor := NewRekor(opts)
 
 	pubkey, err := keypair.GetPublicKeyPem()


### PR DESCRIPTION
When a CI pipeline fails midway, a client may try to upload the same
signed entry again. This will result in Rekor returning a 409.
Additionally, occasionally Rekor v1 fails with a 409 - the root cause
isn't known, it's a flake in Trillian.

This change gracefully handles a 409 Conflict by retrieving the
transparency log entry. For Rekor v1, this is simple, just use the UUID
in the response to lookup the entry by UUID.

Rekor v2 is not handled because we aren't able to fully construct the
TLE without the log's public key, which is the TLE's LogID. A comment
has been added with details on how someone could implement it in the
future.