### PR TITLE
fix(verify): prevent nil-pointer panic in TLogEntries

### DIFF
--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -330,12 +330,12 @@ func (b *Bundle) HasInclusionProof() bool {
 }
 
 func (b *Bundle) TlogEntries() ([]*tlog.Entry, error) {
-	if b == nil {
-		return nil, errors.New("Cannot retrieve tlog entries from a nil bundle")
+	if b.VerificationMaterial == nil {
+		return nil, ErrMissingVerificationMaterial
 	}
 
-	if b.VerificationMaterial == nil {
-		return nil, errors.New("bundle verification material is uninitialized or nil")
+	if len(b.VerificationMaterial.TlogEntries) == 0 {
+		return nil, nil
 	}
 
 	if n := len(b.VerificationMaterial.TlogEntries); n > limits.MaxAllowedTlogEntries {

--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -97,6 +97,11 @@ func (b *Bundle) validate() error {
 		return fmt.Errorf("%w: bundle version %s is not supported", ErrUnsupportedMediaType, bundleVersion)
 	}
 
+	err = validateBundle(b.Bundle)
+	if err != nil {
+		return fmt.Errorf("invalid bundle: %w", err)
+	}
+
 	// fetch tlog entries, as next check needs to check them for inclusion proof/promise
 	entries, err := b.TlogEntries()
 	if err != nil {
@@ -133,10 +138,6 @@ func (b *Bundle) validate() error {
 		return fmt.Errorf("%w: bundle version %s is not yet supported", ErrUnsupportedMediaType, bundleVersion)
 	}
 
-	err = validateBundle(b.Bundle)
-	if err != nil {
-		return fmt.Errorf("invalid bundle: %w", err)
-	}
 	return nil
 }
 
@@ -329,8 +330,12 @@ func (b *Bundle) HasInclusionProof() bool {
 }
 
 func (b *Bundle) TlogEntries() ([]*tlog.Entry, error) {
+	if b == nil {
+		return nil, errors.New("Cannot retrieve tlog entries from a nil bundle")
+	}
+
 	if b.VerificationMaterial == nil {
-		return nil, nil
+		return nil, errors.New("bundle verification material is uninitialized or nil")
 	}
 
 	if n := len(b.VerificationMaterial.TlogEntries); n > limits.MaxAllowedTlogEntries {

--- a/pkg/verify/tlog.go
+++ b/pkg/verify/tlog.go
@@ -50,9 +50,6 @@ func VerifyTlogEntry(entity SignedEntity, trustedMaterial root.TrustedMaterial, 
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve transparency log entries: %w", err)
 	}
-	if len(entries) == 0 {
-		return nil, errors.New("no transparency log entries found to verify")
-	}
 
 	// limit the number of tlog entries to prevent DoS
 	if len(entries) > limits.MaxAllowedTlogEntries {

--- a/pkg/verify/tlog.go
+++ b/pkg/verify/tlog.go
@@ -48,7 +48,10 @@ import (
 func VerifyTlogEntry(entity SignedEntity, trustedMaterial root.TrustedMaterial, logThreshold int, trustIntegratedTime bool) ([]root.Timestamp, error) { //nolint:revive
 	entries, err := entity.TlogEntries()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to retrieve transparency log entries: %w", err)
+	}
+	if len(entries) == 0 {
+		return nil, errors.New("no transparency log entries found to verify")
 	}
 
 	// limit the number of tlog entries to prevent DoS

--- a/pkg/verify/tlog_test.go
+++ b/pkg/verify/tlog_test.go
@@ -165,11 +165,11 @@ func TestNoTLogEntries(t *testing.T) {
 	entity, err := virtualSigstore.Attest("foo@example.com", "issuer", statement)
 	assert.NoError(t, err)
 
-	// failure: empty log entry lists now return a direct error instead of falling through to threshold handling
+	// failure: threshold of 1 is not met with no entries
 	_, err = verify.VerifyTlogEntry(&noTLogEntity{entity}, virtualSigstore, 1, true)
 	assert.Error(t, err)
-	if !strings.Contains(err.Error(), "no transparency log entries found to verify") {
-		t.Errorf("expected error with no tlog entries, got: %v", err.Error())
+	if !strings.Contains(err.Error(), "not enough verified log entries from transparency log") {
+		t.Errorf("expected error with timestamp threshold, got: %v", err.Error())
 	}
 }
 

--- a/pkg/verify/tlog_test.go
+++ b/pkg/verify/tlog_test.go
@@ -165,11 +165,11 @@ func TestNoTLogEntries(t *testing.T) {
 	entity, err := virtualSigstore.Attest("foo@example.com", "issuer", statement)
 	assert.NoError(t, err)
 
-	// failure: threshold of 1 is not met with no entries
+	// failure: empty log entry lists now return a direct error instead of falling through to threshold handling
 	_, err = verify.VerifyTlogEntry(&noTLogEntity{entity}, virtualSigstore, 1, true)
 	assert.Error(t, err)
-	if !strings.Contains(err.Error(), "not enough verified log entries from transparency log") {
-		t.Errorf("expected error with timestamp threshold, got: %v", err.Error())
+	if !strings.Contains(err.Error(), "no transparency log entries found to verify") {
+		t.Errorf("expected error with no tlog entries, got: %v", err.Error())
 	}
 }
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
This PR hardens bundle verification against malformed or empty transparency-log data by adding defensive nil checks to the bundle and verification paths. When a bundle or its verification material is nil or incomplete, verification now returns explicit validation errors instead of panicking with a nil-pointer dereference. This prevents downstream crashes in consumers such as TFLint when processing certain GitHub Artifact Attestations.

Closes TFLint (issue #2591).

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
Fixed a panic during bundle verification for malformed or empty transparency log data in some GitHub Artifact Attestations.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
None. No user-facing documentation changes are required for this bug fix.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Verified locally with:

go test ./pkg/bundle ./pkg/verify