### PR TITLE
Bump linter, disable goconst, run go fix

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -39,7 +39,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.10
+          version: v2.12
           args: --verbose
           # sometimes the pkg cache gets corrupted, skipping cache avoids this
           # https://github.com/golangci/golangci-lint-action/issues/23

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -16,7 +16,6 @@ version: "2"
 linters:
   enable:
     - errorlint
-    - goconst
     - gocritic
     - gosec
     - misspell

--- a/pkg/bundle/bundle_test.go
+++ b/pkg/bundle/bundle_test.go
@@ -1109,7 +1109,7 @@ func Test_BundleValidation(t *testing.T) {
 func TestTlogEntriesCountCap(t *testing.T) {
 	overLimit := limits.MaxAllowedTlogEntries + 1
 	entries := make([]*rekorv1.TransparencyLogEntry, 0, overLimit)
-	for i := 0; i < overLimit; i++ {
+	for range overLimit {
 		entries = append(entries, &rekorv1.TransparencyLogEntry{})
 	}
 
@@ -1132,7 +1132,7 @@ func TestTlogEntriesCountCap(t *testing.T) {
 
 func TestTlogEntriesCountAtCap(t *testing.T) {
 	entries := make([]*rekorv1.TransparencyLogEntry, 0, limits.MaxAllowedTlogEntries)
-	for i := 0; i < limits.MaxAllowedTlogEntries; i++ {
+	for range limits.MaxAllowedTlogEntries {
 		entries = append(entries, &rekorv1.TransparencyLogEntry{})
 	}
 

--- a/pkg/verify/certificate_identity.go
+++ b/pkg/verify/certificate_identity.go
@@ -33,7 +33,7 @@ type SubjectAlternativeNameMatcher struct {
 	//
 	// Note: regexp matching is not anchored by default; use ^...$ if you intend
 	// to match the entire SAN value.
-	Regexp regexp.Regexp `json:"regexp,omitempty"`
+	Regexp regexp.Regexp `json:"regexp"`
 }
 
 // IssuerMatcher specifies how to match a certificate's issuer identity.
@@ -45,7 +45,7 @@ type IssuerMatcher struct {
 	//
 	// Note: regexp matching is not anchored by default; use ^...$ if you intend
 	// to match the entire issuer value.
-	Regexp regexp.Regexp `json:"regexp,omitempty"`
+	Regexp regexp.Regexp `json:"regexp"`
 }
 
 type CertificateIdentity struct {

--- a/pkg/verify/signature_test.go
+++ b/pkg/verify/signature_test.go
@@ -103,7 +103,7 @@ func TestSignatureVerifierMessageSignature(t *testing.T) {
 	virtualSigstore, err := ca.NewVirtualSigstore()
 	assert.NoError(t, err)
 
-	artifact := "Hi, I am an artifact!" //nolint:goconst
+	artifact := "Hi, I am an artifact!"
 	entity, err := virtualSigstore.Sign("foo@example.com", "issuer", []byte(artifact))
 	assert.NoError(t, err)
 
@@ -146,7 +146,7 @@ func TestTooManySubjects(t *testing.T) {
 	verifier, err := verify.NewVerifier(virtualSigstore, verify.WithTransparencyLog(1), verify.WithObserverTimestamps(1))
 	assert.NoError(t, err)
 
-	artifact := "Hi, I am an artifact!" //nolint:goconst
+	artifact := "Hi, I am an artifact!"
 	_, err = verifier.Verify(tooManySubjectsEntity, verify.NewPolicy(verify.WithArtifact(bytes.NewBufferString(artifact)), verify.WithoutIdentitiesUnsafe()))
 	assert.ErrorContains(t, err, "too many subjects")
 }
@@ -176,7 +176,7 @@ func TestTooManyDigests(t *testing.T) {
 	verifier, err := verify.NewVerifier(virtualSigstore, verify.WithTransparencyLog(1), verify.WithObserverTimestamps(1))
 	assert.NoError(t, err)
 
-	artifact := "Hi, I am an artifact!" //nolint:goconst
+	artifact := "Hi, I am an artifact!"
 	_, err = verifier.Verify(tooManySubjectsEntity, verify.NewPolicy(verify.WithArtifact(bytes.NewBufferString(artifact)), verify.WithoutIdentitiesUnsafe()))
 	assert.ErrorContains(t, err, "too many digests")
 }
@@ -321,7 +321,7 @@ func TestCompatibilityAlgorithms(t *testing.T) {
 			assert.NoError(t, err)
 
 			// Create a test artifact
-			artifact := "Hi, I am an artifact!" //nolint:goconst
+			artifact := "Hi, I am an artifact!"
 			h := tt.hash.New()
 			h.Write([]byte(artifact))
 			digest := h.Sum(nil)


### PR DESCRIPTION
Not happy with the linting suggestions from goconst, and we don't have it enabled anywhere else.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
