### PR TITLE
verify: stop materializing in-toto predicates the verifier never reads

### DIFF
--- a/pkg/verify/signature.go
+++ b/pkg/verify/signature.go
@@ -254,7 +254,9 @@ func verifyEnvelopeWithArtifacts(verifier signature.Verifier, envelope EnvelopeC
 	if err := verifyEnvelope(verifier, envelope); err != nil {
 		return err
 	}
-	statement, err := envelope.Statement()
+	// Verification only consumes the statement's subjects; summarizing
+	// avoids materializing the (potentially very large) predicate.
+	statement, err := summarizeStatement(envelope)
 	if err != nil {
 		return fmt.Errorf("could not verify artifact: unable to extract statement from envelope: %w", err)
 	}
@@ -336,7 +338,9 @@ func verifyEnvelopeWithArtifactDigests(verifier signature.Verifier, envelope Env
 	if err := verifyEnvelope(verifier, envelope); err != nil {
 		return err
 	}
-	statement, err := envelope.Statement()
+	// Verification only consumes the statement's subjects; summarizing
+	// avoids materializing the (potentially very large) predicate.
+	statement, err := summarizeStatement(envelope)
 	if err != nil {
 		return fmt.Errorf("could not verify artifact: unable to extract statement from envelope: %w", err)
 	}

--- a/pkg/verify/signed_entity.go
+++ b/pkg/verify/signed_entity.go
@@ -65,6 +65,9 @@ type VerifierConfig struct { // nolint: revive
 	tlogEntriesThreshold int
 	// requireSCTs requires SCTs in Fulcio certificates
 	requireSCTs bool
+	// omitStatementPredicate builds VerificationResult.Statement without
+	// parsing the predicate (Predicate is nil)
+	omitStatementPredicate bool
 	// ctlogEntriesThreshold is the minimum number of verified SCTs in
 	// a Fulcio certificate
 	ctlogEntriesThreshold int
@@ -118,6 +121,24 @@ type SignedEntityVerifier = Verifier
 // Deprecated: Use NewVerifier instead
 func NewSignedEntityVerifier(trustedMaterial root.TrustedMaterial, options ...VerifierOption) (*Verifier, error) {
 	return NewVerifier(trustedMaterial, options...)
+}
+
+// WithoutStatementPredicate configures the Verifier to omit the in-toto
+// statement's predicate from the VerificationResult: Statement carries
+// the statement type, subjects, and predicate type, but Predicate is
+// left nil.
+//
+// Parsing a predicate materializes it as a structpb tree — one heap
+// object per JSON node — which for large predicates (SBOMs,
+// vulnerability reports, build provenance) allocates a large multiple of
+// the payload size. Callers that read the predicate from the verified
+// DSSE payload directly, or do not need it at all, can use this option
+// to avoid that cost.
+func WithoutStatementPredicate() VerifierOption {
+	return func(c *VerifierConfig) error {
+		c.omitStatementPredicate = true
+		return nil
+	}
 }
 
 // WithSignedTimestamps configures the Verifier to expect RFC 3161
@@ -771,7 +792,16 @@ func (v *Verifier) Verify(entity SignedEntity, pb PolicyBuilder) (*VerificationR
 	// SignatureContent can be either an Envelope or a MessageSignature.
 	// If it's an Envelope, let's pop the Statement for our results:
 	if envelope := sigContent.EnvelopeContent(); envelope != nil {
-		stmt, err := envelope.Statement()
+		var stmt *in_toto.Statement
+		var err error
+		if v.config.omitStatementPredicate {
+			// The caller opted out of predicate materialization: the
+			// summary carries the statement type, subjects, and
+			// predicate type, with Predicate left nil.
+			stmt, err = summarizeStatement(envelope)
+		} else {
+			stmt, err = envelope.Statement()
+		}
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch envelope statement: %w", err)
 		}

--- a/pkg/verify/statement.go
+++ b/pkg/verify/statement.go
@@ -1,0 +1,77 @@
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package verify
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	in_toto "github.com/in-toto/attestation/go/v1"
+)
+
+// intotoMediaType is the DSSE payload type carrying in-toto statements.
+const intotoMediaType = "application/vnd.in-toto+json"
+
+// summarizeStatement parses only the statement fields that verification
+// consumes — the statement type, the subjects, and the predicate type —
+// leaving the predicate itself unparsed (the returned Statement's
+// Predicate is nil).
+//
+// Verification never reads the predicate, but predicates dominate
+// statement size in many ecosystems (SBOMs, vulnerability reports, build
+// provenance), sometimes by several orders of magnitude. Materializing
+// them via protojson costs a structpb tree — one heap object per JSON
+// node — which for megabyte-scale predicates allocates a large multiple
+// of the payload size on every parse. Consumers that need the predicate
+// still receive it on the verification result by default; this summary
+// is for code paths that provably do not.
+func summarizeStatement(envelope EnvelopeContent) (*in_toto.Statement, error) {
+	raw := envelope.RawEnvelope()
+	if raw == nil {
+		return nil, errors.New("no DSSE envelope")
+	}
+	if raw.PayloadType != intotoMediaType {
+		return nil, fmt.Errorf("unsupported DSSE payload type: %s", raw.PayloadType)
+	}
+	payload, err := raw.DecodeB64Payload()
+	if err != nil {
+		return nil, fmt.Errorf("decoding DSSE payload: %w", err)
+	}
+
+	var lite struct {
+		Type          string `json:"_type"` //nolint:tagliatelle // in-toto statement field name
+		PredicateType string `json:"predicateType"`
+		Subject       []struct {
+			Name   string            `json:"name"`
+			Digest map[string]string `json:"digest"`
+		} `json:"subject"`
+	}
+	if err := json.Unmarshal(payload, &lite); err != nil {
+		return nil, fmt.Errorf("parsing in-toto statement: %w", err)
+	}
+
+	statement := &in_toto.Statement{
+		Type:          lite.Type,
+		PredicateType: lite.PredicateType,
+	}
+	for _, s := range lite.Subject {
+		statement.Subject = append(statement.Subject, &in_toto.ResourceDescriptor{
+			Name:   s.Name,
+			Digest: s.Digest,
+		})
+	}
+	return statement, nil
+}

--- a/pkg/verify/statement_test.go
+++ b/pkg/verify/statement_test.go
@@ -1,0 +1,166 @@
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package verify
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/secure-systems-lab/go-securesystemslib/dsse"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	in_toto "github.com/in-toto/attestation/go/v1"
+)
+
+// rawEnvelopeContent adapts a bare DSSE envelope to EnvelopeContent for
+// exercising summarizeStatement. Statement() parses the full statement
+// with protojson, mirroring the bundle package's implementation, so the
+// summary can be compared against the canonical parse.
+type rawEnvelopeContent struct {
+	raw *dsse.Envelope
+}
+
+func (r *rawEnvelopeContent) RawEnvelope() *dsse.Envelope { return r.raw }
+
+func (r *rawEnvelopeContent) Statement() (*in_toto.Statement, error) {
+	payload, err := r.raw.DecodeB64Payload()
+	if err != nil {
+		return nil, err
+	}
+	var statement in_toto.Statement
+	if err := protojson.Unmarshal(payload, &statement); err != nil {
+		return nil, err
+	}
+	return &statement, nil
+}
+
+func envelopeWithPayload(t testing.TB, payloadType string, payload []byte) *rawEnvelopeContent {
+	t.Helper()
+	return &rawEnvelopeContent{raw: &dsse.Envelope{
+		PayloadType: payloadType,
+		Payload:     base64.StdEncoding.EncodeToString(payload),
+	}}
+}
+
+// statementJSON builds an in-toto statement document with the given
+// number of subjects and a predicate of roughly predicateEntries keys.
+func statementJSON(t testing.TB, subjects int, predicateEntries int) []byte {
+	t.Helper()
+	doc := map[string]any{
+		"_type":         "https://in-toto.io/Statement/v0.1",
+		"predicateType": "https://example.dev/predicate/v1",
+	}
+	subs := make([]map[string]any, 0, subjects)
+	for i := range subjects {
+		subs = append(subs, map[string]any{
+			"name": fmt.Sprintf("subject-%d", i),
+			"digest": map[string]string{
+				"sha256": fmt.Sprintf("%064d", i),
+				"sha512": fmt.Sprintf("%0128d", i),
+			},
+		})
+	}
+	doc["subject"] = subs
+	predicate := make(map[string]any, predicateEntries)
+	for i := range predicateEntries {
+		predicate[fmt.Sprintf("finding-%06d", i)] = map[string]any{
+			"id":       fmt.Sprintf("VULN-%06d", i),
+			"severity": "High",
+			"detail":   "a moderately sized description string to give the predicate realistic weight",
+		}
+	}
+	doc["predicate"] = predicate
+	raw, err := json.Marshal(doc)
+	require.NoError(t, err)
+	return raw
+}
+
+func TestSummarizeStatementMatchesFullParse(t *testing.T) {
+	env := envelopeWithPayload(t, intotoMediaType, statementJSON(t, 3, 100))
+
+	full, err := env.Statement()
+	require.NoError(t, err)
+	summary, err := summarizeStatement(env)
+	require.NoError(t, err)
+
+	assert.Equal(t, full.Type, summary.Type)
+	assert.Equal(t, full.PredicateType, summary.PredicateType)
+	require.Equal(t, len(full.Subject), len(summary.Subject))
+	for i := range full.Subject {
+		assert.Equal(t, full.Subject[i].Name, summary.Subject[i].Name)
+		assert.Equal(t, full.Subject[i].Digest, summary.Subject[i].Digest)
+	}
+
+	// The full parse materializes the predicate; the summary never does.
+	assert.NotNil(t, full.Predicate)
+	assert.Nil(t, summary.Predicate)
+}
+
+func TestSummarizeStatementErrors(t *testing.T) {
+	t.Run("unsupported payload type", func(t *testing.T) {
+		env := envelopeWithPayload(t, "application/json", statementJSON(t, 1, 0))
+		_, err := summarizeStatement(env)
+		assert.ErrorContains(t, err, "unsupported DSSE payload type")
+	})
+	t.Run("invalid base64", func(t *testing.T) {
+		env := &rawEnvelopeContent{raw: &dsse.Envelope{PayloadType: intotoMediaType, Payload: "!!!"}}
+		_, err := summarizeStatement(env)
+		assert.ErrorContains(t, err, "decoding DSSE payload")
+	})
+	t.Run("invalid JSON", func(t *testing.T) {
+		env := envelopeWithPayload(t, intotoMediaType, []byte("{"))
+		_, err := summarizeStatement(env)
+		assert.ErrorContains(t, err, "parsing in-toto statement")
+	})
+	t.Run("nil envelope", func(t *testing.T) {
+		_, err := summarizeStatement(&rawEnvelopeContent{})
+		assert.ErrorContains(t, err, "no DSSE envelope")
+	})
+}
+
+func TestWithoutStatementPredicate(t *testing.T) {
+	cfg := &VerifierConfig{}
+	require.NoError(t, WithoutStatementPredicate()(cfg))
+	assert.True(t, cfg.omitStatementPredicate)
+}
+
+// BenchmarkStatementParse contrasts the full protojson statement parse
+// with the verification summary on a statement whose predicate carries
+// ~10k entries (about 1.4MiB of JSON) — representative of SBOM and
+// vulnerability-report predicates.
+func BenchmarkStatementParse(b *testing.B) {
+	env := envelopeWithPayload(b, intotoMediaType, statementJSON(b, 2, 10000))
+
+	b.Run("full", func(b *testing.B) {
+		b.ReportAllocs()
+		for range b.N {
+			if _, err := env.Statement(); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("summary", func(b *testing.B) {
+		b.ReportAllocs()
+		for range b.N {
+			if _, err := summarizeStatement(env); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}


### PR DESCRIPTION
#### Summary

While profiling a production service that verifies DSSE bundles whose in-toto predicates run to megabytes (vulnerability reports; SBOM and build-provenance predicates have the same shape), we found that statement parsing dominated the verifier's memory profile, for two compounding reasons:

  1. Envelope.Statement() parses the entire payload with protojson.Unmarshal, which materializes the predicate as a structpb tree: one heap object per JSON node. For large predicates this allocates roughly 10x the payload size and hundreds of thousands of objects per parse, all garbage moments later.

  2. The verification path parses the statement up to three times per bundle (once per artifact-policy check, once to populate the result), multiplying that cost.

Verification itself only ever consumes the statement type, the subjects, and the predicate type. Introduce summarizeStatement, which decodes exactly those fields with encoding/json and leaves Predicate nil, and use it in the artifact-policy verification paths. Building the VerificationResult still parses the full statement by default, so no API behavior changes; a new WithoutStatementPredicate option lets callers that read the predicate from the verified payload directly (or not at all) opt out of materializing it there too.

The included benchmark, on a statement with a ~1.4MiB predicate:

    BenchmarkStatementParse/full       16.0ms/op  14.0MB/op  410152 allocs/op
    BenchmarkStatementParse/summary     4.2ms/op   1.4MB/op      38 allocs/op

i.e. a ~10x reduction in bytes and a four-orders-of-magnitude reduction in object count per parse. In the profiled service, verifying a batch of ~740 such bundles, statement parsing accounted for roughly half of all allocations on the read path; with the verification-path summary plus the opt-out, peak heap during the batch halved.

#### Release Note

Dramatically reduce the amount of wasted memory allocation in the verification path.

#### Documentation

N/A