### PR TITLE
sign: retry Fulcio and TSA requests with httpretry

### DIFF
--- a/pkg/sign/certificate.go
+++ b/pkg/sign/certificate.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math"
 	"net/http"
 	"strings"
 	"time"
@@ -54,11 +53,11 @@ type Fulcio struct {
 type FulcioOptions struct {
 	// URL of Fulcio instance
 	BaseURL string
-	// Optional timeout for network requests (default 30s; use negative value for no timeout)
+	// Optional timeout for the whole request including retries (default 30s; use negative value for no timeout)
 	Timeout time.Duration
-	// Optional number of times to retry on HTTP 5XX
+	// Optional number of times to retry on transient failures (connection errors, HTTP 429, HTTP 5xx other than 501); zero disables retries
 	Retries uint
-	// Optional Transport (for dependency injection)
+	// Optional base Transport (for dependency injection); it is wrapped by the retrying transport, so set Retries to 0 if it already retries
 	Transport http.RoundTripper
 }
 
@@ -98,7 +97,7 @@ type chain struct {
 func NewFulcio(opts *FulcioOptions) *Fulcio {
 	fulcio := &Fulcio{options: opts}
 	fulcio.client = &http.Client{
-		Transport: opts.Transport,
+		Transport: newRetryTransport(opts.Transport, opts.Retries),
 	}
 
 	if opts.Timeout >= 0 {
@@ -172,43 +171,22 @@ func (f *Fulcio) GetCertificate(ctx context.Context, keypair Keypair, opts *Cert
 	//
 	// https://github.com/sigstore/fulcio/pkg/api's client could be used in the
 	// future, when it supports the v2 API
-	attempts := uint(0)
-	var response *http.Response
-
-	for attempts <= f.options.Retries {
-		request, err := http.NewRequest("POST", f.options.BaseURL+"/api/v2/signingCert", bytes.NewBuffer(requestJSON))
-		if err != nil {
-			return nil, err
-		}
-		request.Header.Add("Authorization", "Bearer "+opts.IDToken)
-		request.Header.Add("Content-Type", "application/json")
-		request.Header.Add("User-Agent", util.ConstructUserAgent())
-
-		response, err = f.client.Do(request) // #nosec G704 -- Client controls the URL
-		if err != nil {
-			return nil, err
-		}
-
-		if (response.StatusCode < 500 || response.StatusCode >= 600) && response.StatusCode != 429 {
-			// Not a retryable HTTP status code, so don't retry
-			break
-		}
-
-		response.Body.Close()
-
-		delay := time.Duration(math.Pow(2, float64(attempts)))
-		timer := time.NewTimer(delay * time.Second)
-		select {
-		case <-ctx.Done():
-			timer.Stop()
-			return nil, ctx.Err()
-		case <-timer.C:
-		}
-		attempts++
+	//
+	// Transient failures are retried by the client's transport; see
+	// newRetryTransport.
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, f.options.BaseURL+"/api/v2/signingCert", bytes.NewBuffer(requestJSON))
+	if err != nil {
+		return nil, err
 	}
-	if response != nil && response.Body != nil {
-		defer response.Body.Close()
+	request.Header.Add("Authorization", "Bearer "+opts.IDToken)
+	request.Header.Add("Content-Type", "application/json")
+	request.Header.Add("User-Agent", util.ConstructUserAgent())
+
+	response, err := f.client.Do(request) // #nosec G704 -- Client controls the URL
+	if err != nil {
+		return nil, err
 	}
+	defer response.Body.Close()
 
 	body, err := io.ReadAll(io.LimitReader(response.Body, 1<<20))
 	if err != nil {

--- a/pkg/sign/certificate_test.go
+++ b/pkg/sign/certificate_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"io"
 	"net/http"
 	"sync"
@@ -97,20 +98,37 @@ func (m *mockFulcio) RoundTrip(_ *http.Request) (*http.Response, error) {
 
 type failFirstFulcio struct {
 	Count       int
+	Attempts    int
 	detachedSct bool
 }
 
 func (f *failFirstFulcio) RoundTrip(_ *http.Request) (*http.Response, error) {
+	f.Attempts++
 	if f.Count <= 0 {
 		f.Count++
 		response := &http.Response{
 			StatusCode: 500,
-			Body:       io.NopCloser(bytes.NewReader([]byte(""))),
+			Body:       io.NopCloser(bytes.NewReader([]byte("internal error"))),
 		}
 		return response, nil
 	}
 
 	return getFulcioResponse(f.detachedSct)
+}
+
+// errorFirstFulcio returns a transport error on the first attempt and
+// succeeds afterwards.
+type errorFirstFulcio struct {
+	Attempts int
+}
+
+func (e *errorFirstFulcio) RoundTrip(_ *http.Request) (*http.Response, error) {
+	e.Attempts++
+	if e.Attempts == 1 {
+		return nil, errors.New("connection reset by peer")
+	}
+
+	return getFulcioResponse(false)
 }
 
 func Test_GetCertificate(t *testing.T) {
@@ -139,16 +157,39 @@ func Test_GetCertificate(t *testing.T) {
 	roundTripper := &failFirstFulcio{}
 	retryFulcioOpts := &FulcioOptions{Retries: 1, Transport: roundTripper}
 	retryFulcio := NewFulcio(retryFulcioOpts)
+	disableBackoff(t, retryFulcio.client.Transport)
 
 	cert, err = retryFulcio.GetCertificate(ctx, keypair, certOpts)
 	assert.NotNil(t, cert)
 	assert.Nil(t, err)
+	assert.Equal(t, 2, roundTripper.Attempts)
 
-	// Test unsuccessful retry
+	// Test unsuccessful retry; the final response body is included in the error
 	roundTripper.Count = -1
+	roundTripper.Attempts = 0
 	cert, err = retryFulcio.GetCertificate(ctx, keypair, certOpts)
 	assert.Nil(t, cert)
-	assert.NotNil(t, err)
+	assert.ErrorContains(t, err, "Fulcio returned 500: internal error")
+	assert.Equal(t, 2, roundTripper.Attempts)
+
+	// Test that transport errors are retried
+	errorTripper := &errorFirstFulcio{}
+	errorFulcio := NewFulcio(&FulcioOptions{Retries: 1, Transport: errorTripper})
+	disableBackoff(t, errorFulcio.client.Transport)
+
+	cert, err = errorFulcio.GetCertificate(ctx, keypair, certOpts)
+	assert.NotNil(t, cert)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, errorTripper.Attempts)
+
+	// Test that zero retries means a single attempt
+	noRetryTripper := &failFirstFulcio{}
+	noRetryFulcio := NewFulcio(&FulcioOptions{Retries: 0, Transport: noRetryTripper})
+
+	cert, err = noRetryFulcio.GetCertificate(ctx, keypair, certOpts)
+	assert.Nil(t, cert)
+	assert.ErrorContains(t, err, "Fulcio returned 500")
+	assert.Equal(t, 1, noRetryTripper.Attempts)
 
 	// Test detached SCT
 	detachedOpts := &FulcioOptions{Retries: 1, Transport: &mockFulcio{detachedSct: true}}

--- a/pkg/sign/retry.go
+++ b/pkg/sign/retry.go
@@ -1,0 +1,38 @@
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sign
+
+import (
+	"math"
+	"net/http"
+
+	"github.com/sigstore/sigstore/pkg/httpretry"
+)
+
+// newRetryTransport wraps base (nil means http.DefaultTransport) in an
+// httpretry.Transport that retries transient failures (connection errors,
+// HTTP 429, and HTTP 5xx other than 501) up to retries times, using jittered
+// exponential backoff that honors Retry-After. A retries value of zero
+// disables retrying.
+func newRetryTransport(base http.RoundTripper, retries uint) *httpretry.Transport {
+	transport := httpretry.NewTransport(base)
+	// Bound the conversion so it cannot overflow.
+	maxRetries := math.MaxInt
+	if retries < math.MaxInt {
+		maxRetries = int(retries)
+	}
+	transport.MaxRetries = maxRetries
+	return transport
+}

--- a/pkg/sign/retry_test.go
+++ b/pkg/sign/retry_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sign
+
+import (
+	"math"
+	"net/http"
+	"testing"
+
+	"github.com/sigstore/sigstore/pkg/httpretry"
+	"github.com/stretchr/testify/assert"
+)
+
+// disableBackoff removes the wait between retry attempts so tests that
+// exercise the retry path do not sleep.
+func disableBackoff(t *testing.T, rt http.RoundTripper) {
+	t.Helper()
+	transport, ok := rt.(*httpretry.Transport)
+	if !ok {
+		t.Fatalf("expected *httpretry.Transport, got %T", rt)
+	}
+	transport.WaitMin = 0
+	transport.WaitMax = 0
+}
+
+func Test_newRetryTransport(t *testing.T) {
+	base := &mockFulcio{}
+	transport := newRetryTransport(base, 3)
+	assert.Equal(t, base, transport.Base)
+	assert.Equal(t, 3, transport.MaxRetries)
+
+	assert.Nil(t, newRetryTransport(nil, 0).Base)
+	assert.Equal(t, 0, newRetryTransport(nil, 0).MaxRetries)
+	assert.Equal(t, math.MaxInt, newRetryTransport(nil, math.MaxUint).MaxRetries)
+}

--- a/pkg/sign/timestamping.go
+++ b/pkg/sign/timestamping.go
@@ -21,7 +21,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"math"
 	"net/http"
 	"time"
 
@@ -33,11 +32,11 @@ import (
 type TimestampAuthorityOptions struct {
 	// Full URL (with path) of Timestamp Authority endpoint
 	URL string
-	// Optional timeout for network requests (default 30s; use negative value for no timeout)
+	// Optional timeout for the whole request including retries (default 30s; use negative value for no timeout)
 	Timeout time.Duration
-	// Optional number of times to retry on HTTP 5XX
+	// Optional number of times to retry on transient failures (connection errors, HTTP 429, HTTP 5xx other than 501); zero disables retries
 	Retries uint
-	// Optional Transport (for dependency injection)
+	// Optional base Transport (for dependency injection); it is wrapped by the retrying transport, so set Retries to 0 if it already retries
 	Transport http.RoundTripper
 }
 
@@ -51,7 +50,7 @@ var TimestampAuthorityAPIVersions = []uint32{1}
 func NewTimestampAuthority(opts *TimestampAuthorityOptions) *TimestampAuthority {
 	ta := &TimestampAuthority{options: opts}
 	ta.client = &http.Client{
-		Transport: opts.Transport,
+		Transport: newRetryTransport(opts.Transport, opts.Retries),
 	}
 
 	if opts.Timeout >= 0 {
@@ -76,42 +75,20 @@ func (ta *TimestampAuthority) GetTimestamp(ctx context.Context, signature []byte
 		return nil, err
 	}
 
-	attempts := uint(0)
-	var response *http.Response
-
-	for attempts <= ta.options.Retries {
-		request, err := http.NewRequest("POST", ta.options.URL, bytes.NewReader(reqBytes))
-		if err != nil {
-			return nil, err
-		}
-		request.Header.Add("Content-Type", "application/timestamp-query")
-		request.Header.Add("User-Agent", util.ConstructUserAgent())
-
-		response, err = ta.client.Do(request) // #nosec G704 -- Client controls the URL
-		if err != nil {
-			return nil, err
-		}
-
-		if (response.StatusCode < 500 || response.StatusCode >= 600) && response.StatusCode != 429 {
-			// Not a retryable HTTP status code, so don't retry
-			break
-		}
-
-		response.Body.Close()
-
-		delay := time.Duration(math.Pow(2, float64(attempts)))
-		timer := time.NewTimer(delay * time.Second)
-		select {
-		case <-ctx.Done():
-			timer.Stop()
-			return nil, ctx.Err()
-		case <-timer.C:
-		}
-		attempts++
+	// Transient failures are retried by the client's transport; see
+	// newRetryTransport.
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, ta.options.URL, bytes.NewReader(reqBytes))
+	if err != nil {
+		return nil, err
 	}
-	if response != nil && response.Body != nil {
-		defer response.Body.Close()
+	request.Header.Add("Content-Type", "application/timestamp-query")
+	request.Header.Add("User-Agent", util.ConstructUserAgent())
+
+	response, err := ta.client.Do(request) // #nosec G704 -- Client controls the URL
+	if err != nil {
+		return nil, err
 	}
+	defer response.Body.Close()
 
 	body, err := io.ReadAll(io.LimitReader(response.Body, 1<<20))
 	if err != nil {

--- a/pkg/sign/timestamping_test.go
+++ b/pkg/sign/timestamping_test.go
@@ -17,6 +17,7 @@ package sign
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"testing"
@@ -55,17 +56,39 @@ func (m *mockTSAClient) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 type failFirstTSA struct {
-	Count int
+	Count    int
+	Attempts int
 }
 
 func (f *failFirstTSA) RoundTrip(req *http.Request) (*http.Response, error) {
+	f.Attempts++
 	if f.Count <= 0 {
 		f.Count++
 		response := &http.Response{
 			StatusCode: 500,
-			Body:       io.NopCloser(bytes.NewReader([]byte(""))),
+			Body:       io.NopCloser(bytes.NewReader([]byte("internal error"))),
 		}
 		return response, nil
+	}
+	reqBytes, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return getTSAResponse(reqBytes)
+}
+
+// errorFirstTSA returns a transport error on the first attempt and succeeds
+// afterwards. Reading the request body on the retry verifies that the body
+// was replayed.
+type errorFirstTSA struct {
+	Attempts int
+}
+
+func (e *errorFirstTSA) RoundTrip(req *http.Request) (*http.Response, error) {
+	e.Attempts++
+	if e.Attempts == 1 {
+		return nil, errors.New("connection reset by peer")
 	}
 	reqBytes, err := io.ReadAll(req.Body)
 	if err != nil {
@@ -89,13 +112,34 @@ func Test_GetTimestamp(t *testing.T) {
 	failFirstClient := &failFirstTSA{}
 	retryOpts := &TimestampAuthorityOptions{Retries: 1, Transport: failFirstClient}
 	retryTSA := NewTimestampAuthority(retryOpts)
+	disableBackoff(t, retryTSA.client.Transport)
 	resp, err = retryTSA.GetTimestamp(ctx, signature)
 	assert.NotNil(t, resp)
 	assert.Nil(t, err)
+	assert.Equal(t, 2, failFirstClient.Attempts)
 
-	// Test unsuccessful retry
+	// Test unsuccessful retry; the final response body is included in the error
 	failFirstClient.Count = -1
+	failFirstClient.Attempts = 0
 	resp, err = retryTSA.GetTimestamp(ctx, signature)
 	assert.Nil(t, resp)
-	assert.NotNil(t, err)
+	assert.ErrorContains(t, err, "timestamp authority returned 500: internal error")
+	assert.Equal(t, 2, failFirstClient.Attempts)
+
+	// Test that transport errors are retried and the request body is replayed
+	errorClient := &errorFirstTSA{}
+	errorTSA := NewTimestampAuthority(&TimestampAuthorityOptions{Retries: 1, Transport: errorClient})
+	disableBackoff(t, errorTSA.client.Transport)
+	resp, err = errorTSA.GetTimestamp(ctx, signature)
+	assert.NotNil(t, resp)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, errorClient.Attempts)
+
+	// Test that zero retries means a single attempt
+	noRetryClient := &failFirstTSA{}
+	noRetryTSA := NewTimestampAuthority(&TimestampAuthorityOptions{Retries: 0, Transport: noRetryClient})
+	resp, err = noRetryTSA.GetTimestamp(ctx, signature)
+	assert.Nil(t, resp)
+	assert.ErrorContains(t, err, "timestamp authority returned 500")
+	assert.Equal(t, 1, noRetryClient.Attempts)
 }


### PR DESCRIPTION
The Fulcio and timestamp authority clients each carried a hand-rolled retry loop: retry only on 5xx/429 with a fixed 2^n-second backoff (no cap, no jitter, no Retry-After), no retry on connection errors, a request built without the caller's context, and on exhaustion the response body was closed inside the loop and then read again, so the returned error lost the server's message. #671 brought in sigstore/sigstore's `httpretry` package for the TUF fetcher; this PR moves Fulcio and TSA onto the same package so sigstore-go has one retry policy rather than three.

Behaviour changes for reviewers: connection errors are now retried; backoff is jittered exponential (1s floor, 30s cap) and honours Retry-After; 501 is no longer retried; `Timeout` now bounds the whole call including backoff rather than each attempt, matching how Rekor v1's go-openapi timeout already behaves; `Retries: 0` still means a single attempt. Rekor v1 is unchanged (rekor's client retries internally). Rekor v2 will follow in a separate PR once rekor-tiles exposes a transport option.

Key changes:
- **`newRetryTransport` helper** (`pkg/sign/retry.go`): wraps an optional base transport in `httpretry.Transport` with `MaxRetries` taken from the `Retries` option (clamped for gosec G115); shared by Fulcio and TSA, and by Rekor v2 later.
- **Retry loops removed**: `GetCertificate` and `GetTimestamp` issue one `http.NewRequestWithContext` + `client.Do`; the `bytes.Buffer`/`bytes.Reader` bodies set `GetBody`, so the POSTs are replayable and headers such as `Authorization` are re-sent via `Request.Clone`.
- **Option docs**: `Timeout`, `Retries`, and `Transport` comments describe the new semantics; an injected `Transport` is now wrapped, so callers whose transport already retries should set `Retries: 0`.
- **Tests**: existing mock transports keep working; backoff is zeroed per instance via `disableBackoff` so the retry tests no longer sleep (~6s saved); new cases cover transport-error retry, `Retries: 0` making a single attempt, and the exhaustion error including the response body.

Assisted by Claude Fable 5.1